### PR TITLE
Maintainer sweep

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,8 +32,8 @@
     <PackageVersion Include="Polly" Version="8.7.0" />
     <PackageVersion Include="Polly.RateLimiting" Version="8.7.0" />
     <!-- Media Playback -->
-    <PackageVersion Include="LibVLCSharp" Version="4.0.0-alpha-20260709-10120" />
-    <PackageVersion Include="VideoLAN.LibVLC.Windows" Version="4.0.0-alpha-20260709" />
+    <PackageVersion Include="LibVLCSharp" Version="4.0.0-alpha-20260828-10280" />
+    <PackageVersion Include="VideoLAN.LibVLC.Windows" Version="4.0.0-alpha-20260830" />
     <!-- Serilog -->
     <PackageVersion Include="Serilog.Enrichers.Thread" Version="4.0.0" />
     <PackageVersion Include="Serilog.Extensions.Logging" Version="10.0.0" />

--- a/src/Nagi.Core/Services/Abstractions/ILrcService.cs
+++ b/src/Nagi.Core/Services/Abstractions/ILrcService.cs
@@ -23,6 +23,21 @@ public interface ILrcService
     Task<ParsedLrc?> GetLyricsAsync(string lrcFilePath);
 
     /// <summary>
+    ///     Saves a user-provided lyrics override in Nagi's cache for the song.
+    /// </summary>
+    Task SaveLyricsAsync(Song song, string lrcContent);
+
+    /// <summary>
+    ///     Removes lyrics stored in Nagi's cache without deleting external sidecar files.
+    /// </summary>
+    Task<bool> RemoveCachedLyricsAsync(Song song);
+
+    /// <summary>
+    ///     Returns whether the song currently points to a lyrics file managed by Nagi.
+    /// </summary>
+    bool HasCachedLyrics(Song song);
+
+    /// <summary>
     ///     Parses a raw LRC string into a ParsedLrc object, which may contain synced or unsynced lyrics.
     /// </summary>
     /// <param name="lrcContent">The raw LRC string content.</param>

--- a/src/Nagi.Core/Services/Abstractions/ISettingsService.cs
+++ b/src/Nagi.Core/Services/Abstractions/ISettingsService.cs
@@ -334,6 +334,16 @@ public interface ISettingsService
     Task SetVolumeNormalizationEnabledAsync(bool isEnabled);
 
     /// <summary>
+    ///     Gets whether VLC should request exclusive access to the Windows audio device.
+    /// </summary>
+    Task<bool> GetWasapiExclusiveModeEnabledAsync();
+
+    /// <summary>
+    ///     Sets whether VLC should request exclusive access to the Windows audio device.
+    /// </summary>
+    Task SetWasapiExclusiveModeEnabledAsync(bool isEnabled);
+
+    /// <summary>
     ///     Gets whether fade on play/pause is enabled.
     /// </summary>
     Task<bool> GetFadeOnPlayPauseEnabledAsync();

--- a/src/Nagi.Core/Services/Implementations/LrcService.cs
+++ b/src/Nagi.Core/Services/Implementations/LrcService.cs
@@ -206,34 +206,65 @@ public class LrcService : ILrcService, IDisposable
         }
     }
 
+    /// <inheritdoc />
+    public Task SaveLyricsAsync(Song song, string lrcContent)
+    {
+        ArgumentNullException.ThrowIfNull(song);
+        ArgumentException.ThrowIfNullOrWhiteSpace(lrcContent);
+        return WriteLyricsCacheAsync(song, lrcContent);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> RemoveCachedLyricsAsync(Song song)
+    {
+        ArgumentNullException.ThrowIfNull(song);
+        if (!HasCachedLyrics(song)) return false;
+
+        var cachedPath = song.LrcFilePath!;
+        if (_fileSystemService.FileExists(cachedPath)) _fileSystemService.DeleteFile(cachedPath);
+
+        song.LrcFilePath = null;
+        song.LyricsLastCheckedUtc = DateTime.UtcNow;
+        await _libraryWriter.UpdateSongLrcPathAsync(song.Id, null).ConfigureAwait(false);
+        await _libraryWriter.UpdateSongLyricsLastCheckedAsync(song.Id).ConfigureAwait(false);
+        return true;
+    }
+
+    /// <inheritdoc />
+    public bool HasCachedLyrics(Song song)
+    {
+        ArgumentNullException.ThrowIfNull(song);
+        return IsCachePath(song.LrcFilePath);
+    }
+
     private async Task CacheLyricsAsync(Song song, string lrcContent)
     {
         try
         {
-            var cacheIdentity = string.IsNullOrWhiteSpace(song.FilePath) ? song.Id.ToString("N") : song.FilePath;
-            var cacheFileName = FileNameHelper.GenerateLrcCacheFileName(
-                cacheIdentity,
-                song.PrimaryArtistName,
-                song.Album?.Title,
-                song.Title);
-            var cachedLrcPath = _fileSystemService.Combine(_pathConfig.LrcCachePath, cacheFileName);
-
-            await _fileSystemService.WriteAllTextAsync(cachedLrcPath, lrcContent).ConfigureAwait(false);
-            _logger.LogDebug("Cached online lyrics for song {SongId} to {Path}", song.Id, cachedLrcPath);
-
-            // Update the database only if the path has changed
-            if (song.LrcFilePath != cachedLrcPath)
-            {
-                song.LrcFilePath = cachedLrcPath;
-                // We don't persist the full text to 'Lyrics' column here to keep the DB light,
-                // as we rely on the LRC file. The 'Lyrics' column is mostly for unsynced lyrics.
-                await _libraryWriter.UpdateSongLrcPathAsync(song.Id, cachedLrcPath).ConfigureAwait(false);
-            }
+            await WriteLyricsCacheAsync(song, lrcContent).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to cache lyrics for song {SongId}", song.Id);
         }
+    }
+
+    private async Task WriteLyricsCacheAsync(Song song, string lrcContent)
+    {
+        var cacheIdentity = string.IsNullOrWhiteSpace(song.FilePath) ? song.Id.ToString("N") : song.FilePath;
+        var cacheFileName = FileNameHelper.GenerateLrcCacheFileName(
+            cacheIdentity,
+            song.PrimaryArtistName,
+            song.Album?.Title,
+            song.Title);
+        var cachedLrcPath = _fileSystemService.Combine(_pathConfig.LrcCachePath, cacheFileName);
+
+        await _fileSystemService.WriteAllTextAsync(cachedLrcPath, lrcContent).ConfigureAwait(false);
+        _logger.LogDebug("Cached lyrics for song {SongId} to {Path}", song.Id, cachedLrcPath);
+
+        if (song.LrcFilePath == cachedLrcPath) return;
+        song.LrcFilePath = cachedLrcPath;
+        await _libraryWriter.UpdateSongLrcPathAsync(song.Id, cachedLrcPath).ConfigureAwait(false);
     }
 
     private bool IsLegacyCachePath(Song song)
@@ -242,12 +273,20 @@ public class LrcService : ILrcService, IDisposable
             || string.IsNullOrWhiteSpace(_pathConfig.LrcCachePath))
             return false;
 
-        var cacheRoot = PathCanonicalizer.Normalize(_pathConfig.LrcCachePath).TrimEnd('\\') + "\\";
-        var candidate = PathCanonicalizer.Normalize(song.LrcFilePath);
-        if (!candidate.StartsWith(cacheRoot, StringComparison.OrdinalIgnoreCase)) return false;
+        if (!IsCachePath(song.LrcFilePath)) return false;
 
         var cacheIdentity = string.IsNullOrWhiteSpace(song.FilePath) ? song.Id.ToString("N") : song.FilePath;
+        var candidate = PathCanonicalizer.Normalize(song.LrcFilePath);
         return !FileNameHelper.MatchesLrcCacheIdentity(candidate, cacheIdentity);
+    }
+
+    private bool IsCachePath(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path) || string.IsNullOrWhiteSpace(_pathConfig.LrcCachePath)) return false;
+
+        var cacheRoot = PathCanonicalizer.Normalize(_pathConfig.LrcCachePath).TrimEnd('\\') + "\\";
+        var candidate = PathCanonicalizer.Normalize(path);
+        return candidate.StartsWith(cacheRoot, StringComparison.OrdinalIgnoreCase);
     }
 
     private Task<string?> LogUnknownProviderAndReturnNull(string providerId)

--- a/src/Nagi.WinUI/App.xaml.cs
+++ b/src/Nagi.WinUI/App.xaml.cs
@@ -653,6 +653,7 @@ public partial class App : Application
         services.AddSingleton<IAudioPlayer>(provider =>
             new LibVlcAudioPlayerService(provider.GetRequiredService<IDispatcherService>(),
                 provider.GetRequiredService<IAppInfoService>(),
+                provider.GetRequiredService<ISettingsService>(),
                 provider.GetRequiredService<ILogger<LibVlcAudioPlayerService>>()));
         services.AddTransient<ITaskbarService>(provider =>
             new TaskbarService(

--- a/src/Nagi.WinUI/Controls/TrayIconUserControl.xaml
+++ b/src/Nagi.WinUI/Controls/TrayIconUserControl.xaml
@@ -18,7 +18,7 @@
         IconSource="ms-appx:///Assets/AppLogo.ico"
         LeftClickCommand="{x:Bind ViewModel.ShowPopupCommand}"
         LeftClickCommandParameter="{Binding RelativeSource={RelativeSource Self}}"
-        NoLeftClickDelay="True"
+        DoubleClickCommand="{x:Bind ViewModel.RestoreWindowCommand}"
         ToolTipText="{x:Bind ViewModel.ToolTipText, Mode=OneWay}"
         ContextMenuMode="SecondWindow">
 

--- a/src/Nagi.WinUI/MainPage.xaml
+++ b/src/Nagi.WinUI/MainPage.xaml
@@ -608,6 +608,11 @@
                     TextAlignment="Center"
                     TextTrimming="CharacterEllipsis"
                     TextWrapping="NoWrap" />
+                <Button
+                    HorizontalAlignment="Center"
+                    Command="{x:Bind ViewModel.CancelGlobalOperationCommand}"
+                    Content="{x:Bind resources:Strings.Generic_Cancel, Mode=OneTime}"
+                    Visibility="{x:Bind ViewModel.CanCancelGlobalOperation, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}" />
             </StackPanel>
         </Grid>
 

--- a/src/Nagi.WinUI/Pages/AlbumPage.xaml
+++ b/src/Nagi.WinUI/Pages/AlbumPage.xaml
@@ -122,6 +122,7 @@
                     FontSize="13"
                     Foreground="{ThemeResource TextFillColorSecondary}"
                     Text="{x:Bind ViewModel.TotalItemsText, Mode=OneWay}" />
+                <uicontrols:PaginationControl ViewModel="{x:Bind ViewModel}" />
             </StackPanel>
 
             <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
@@ -199,6 +200,7 @@
                 IsItemClickEnabled="True"
                 ItemClick="AlbumsGridView_ItemClick"
                 Padding="{StaticResource SongListViewPadding}"
+                Margin="{StaticResource SongListViewMargin}"
                 ItemContainerStyle="{StaticResource AlbumPageGridViewItemStyle}"
                 ItemsSource="{x:Bind ViewModel.Albums, Mode=OneWay}"
                 SelectionMode="None"
@@ -277,12 +279,6 @@
                         </Grid>
                     </DataTemplate>
                 </GridView.ItemTemplate>
-                <GridView.Footer>
-                    <uicontrols:PaginationControl
-                        ViewModel="{x:Bind ViewModel}"
-                        HorizontalAlignment="Right"
-                        Margin="0,24,24,16" />
-                </GridView.Footer>
             </GridView>
 
             <!-- Message shown when the library is empty -->

--- a/src/Nagi.WinUI/Pages/AlbumViewPage.xaml
+++ b/src/Nagi.WinUI/Pages/AlbumViewPage.xaml
@@ -155,6 +155,7 @@
                                Foreground="{ThemeResource TextFillColorSecondary}" VerticalAlignment="Center"
                                FontSize="13"
                                Visibility="{x:Bind ViewModel.HasSelectedSongs, Mode=OneWay, Converter={StaticResource InverseBooleanToVisibilityConverter}}" />
+                    <uicontrols:PaginationControl ViewModel="{x:Bind ViewModel}" />
                 </StackPanel>
 
                 <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
@@ -235,6 +236,7 @@
             Grid.Row="1"
             x:Name="GroupedSongsListView"
             Padding="{StaticResource SongListViewPadding}"
+            Margin="{StaticResource SongListViewMargin}"
             IsItemClickEnabled="True"
             ItemsSource="{x:Bind ViewModel.GroupedSongsFlat, Mode=OneWay}"
             SelectionChanged="GroupedSongsListView_SelectionChanged"
@@ -242,12 +244,6 @@
             ContainerContentChanging="OnSongsListViewContainerContentChanging"
             DoubleTapped="GroupedSongsListView_DoubleTapped"
             Visibility="{x:Bind ViewModel.IsGroupedByDisc, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
-            <ListView.Footer>
-                <uicontrols:PaginationControl
-                    ViewModel="{x:Bind ViewModel}"
-                    HorizontalAlignment="Right"
-                    Margin="0,24,24,16" />
-            </ListView.Footer>
             <ListView.ItemContainerStyleSelector>
                 <local:DiscGroupStyleSelector>
                     <local:DiscGroupStyleSelector.HeaderStyle>
@@ -318,6 +314,7 @@
             Grid.Row="1"
             x:Name="SongsListView"
             Padding="{StaticResource SongListViewPadding}"
+            Margin="{StaticResource SongListViewMargin}"
             IsItemClickEnabled="True"
             ItemContainerStyle="{StaticResource SongListViewPageListViewItemStyle}"
             ItemsSource="{x:Bind ViewModel.Songs, Mode=OneWay}"
@@ -326,12 +323,6 @@
             ContainerContentChanging="OnSongsListViewContainerContentChanging"
             DoubleTapped="SongsListView_DoubleTapped"
             Visibility="{x:Bind ViewModel.IsGroupedByDisc, Mode=OneWay, Converter={StaticResource InverseBooleanToVisibilityConverter}}">
-            <ListView.Footer>
-                <uicontrols:PaginationControl
-                    ViewModel="{x:Bind ViewModel}"
-                    HorizontalAlignment="Right"
-                    Margin="0,24,24,16" />
-            </ListView.Footer>
             <ListView.ItemTemplate>
                 <DataTemplate x:DataType="models:Song">
                     <Grid Height="54" ColumnSpacing="12" Background="Transparent">

--- a/src/Nagi.WinUI/Pages/ArtistPage.xaml
+++ b/src/Nagi.WinUI/Pages/ArtistPage.xaml
@@ -121,6 +121,7 @@
                     FontSize="13"
                     Foreground="{ThemeResource TextFillColorSecondary}"
                     Text="{x:Bind ViewModel.TotalItemsText, Mode=OneWay}" />
+                <uicontrols:PaginationControl ViewModel="{x:Bind ViewModel}" />
             </StackPanel>
 
             <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
@@ -186,6 +187,7 @@
                 IsItemClickEnabled="True"
                 ItemClick="ArtistsGridView_ItemClick"
                 Padding="{StaticResource SongListViewPadding}"
+                Margin="{StaticResource SongListViewMargin}"
                 ItemContainerStyle="{StaticResource ArtistPageGridViewItemStyle}"
                 ItemsSource="{x:Bind ViewModel.Artists, Mode=OneWay}"
                 SelectionMode="None"
@@ -259,12 +261,6 @@
                         </Grid>
                     </DataTemplate>
                 </GridView.ItemTemplate>
-                <GridView.Footer>
-                    <uicontrols:PaginationControl
-                        ViewModel="{x:Bind ViewModel}"
-                        HorizontalAlignment="Right"
-                        Margin="0,24,24,16" />
-                </GridView.Footer>
             </GridView>
 
             <!-- Message shown when the library is empty -->

--- a/src/Nagi.WinUI/Pages/ArtistViewPage.xaml
+++ b/src/Nagi.WinUI/Pages/ArtistViewPage.xaml
@@ -341,6 +341,7 @@
                                    Foreground="{ThemeResource TextFillColorSecondary}"
                                    Text="{x:Bind ViewModel.TotalItemsText, Mode=OneWay}"
                                    Visibility="{x:Bind ViewModel.HasSelectedSongs, Mode=OneWay, Converter={StaticResource InverseBooleanToVisibilityConverter}}" />
+                        <uicontrols:PaginationControl ViewModel="{x:Bind ViewModel}" />
                     </StackPanel>
                     <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
                         <!-- Search functionality -->
@@ -420,6 +421,7 @@
             Grid.Row="1"
             x:Name="SongsListView"
             Padding="{StaticResource SongListViewPadding}"
+            Margin="{StaticResource SongListViewMargin}"
             IsItemClickEnabled="True"
             ItemContainerStyle="{StaticResource SongListViewPageListViewItemStyle}"
             ItemsSource="{x:Bind ViewModel.Songs, Mode=OneWay}"
@@ -427,12 +429,6 @@
             SelectionMode="Extended"
             ContainerContentChanging="OnSongsListViewContainerContentChanging"
             DoubleTapped="SongsListView_DoubleTapped">
-            <ListView.Footer>
-                <uicontrols:PaginationControl
-                    ViewModel="{x:Bind ViewModel}"
-                    HorizontalAlignment="Right"
-                    Margin="0,24,24,16" />
-            </ListView.Footer>
             <ListView.ItemTemplate>
                 <DataTemplate x:DataType="models:Song">
                     <Grid Height="54" ColumnSpacing="12" Background="Transparent">

--- a/src/Nagi.WinUI/Pages/FolderPage.xaml
+++ b/src/Nagi.WinUI/Pages/FolderPage.xaml
@@ -56,6 +56,7 @@
             ItemContainerStyle="{StaticResource FolderPageGridViewItemStyle}"
             ItemsSource="{x:Bind ViewModel.Folders, Mode=OneWay}"
             Padding="{StaticResource SongListViewPadding}"
+            Margin="{StaticResource SongListViewMargin}"
             Visibility="{x:Bind ViewModel.HasFolders, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}">
             <GridView.ItemsPanel>
                 <ItemsPanelTemplate>

--- a/src/Nagi.WinUI/Pages/FolderSongViewPage.xaml
+++ b/src/Nagi.WinUI/Pages/FolderSongViewPage.xaml
@@ -312,6 +312,7 @@
                                Foreground="{ThemeResource TextFillColorSecondary}" VerticalAlignment="Center"
                                FontSize="13"
                                Visibility="{x:Bind ViewModel.HasSelectedSongs, Mode=OneWay, Converter={StaticResource InverseBooleanToVisibilityConverter}}" />
+                    <uicontrols:PaginationControl ViewModel="{x:Bind ViewModel}" />
                 </StackPanel>
 
                 <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
@@ -399,6 +400,7 @@
             x:Name="FolderContentsListView"
             Grid.Row="1"
             Padding="{StaticResource SongListViewPadding}"
+            Margin="{StaticResource SongListViewMargin}"
             IsItemClickEnabled="True"
             ItemClick="FolderContentsListView_ItemClick"
             ItemContainerStyle="{StaticResource SongListViewPageListViewItemStyle}"
@@ -408,12 +410,6 @@
             SelectionMode="Extended"
             ContainerContentChanging="OnSongsListViewContainerContentChanging"
             DoubleTapped="FolderContentsListView_DoubleTapped">
-            <ListView.Footer>
-                <uicontrols:PaginationControl
-                    ViewModel="{x:Bind ViewModel}"
-                    HorizontalAlignment="Right"
-                    Margin="0,24,24,16" />
-            </ListView.Footer>
         </ListView>
 
         <!-- Empty State -->

--- a/src/Nagi.WinUI/Pages/GenrePage.xaml
+++ b/src/Nagi.WinUI/Pages/GenrePage.xaml
@@ -169,6 +169,7 @@
                 SelectionMode="None"
                 Visibility="{x:Bind ViewModel.HasGenres, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}"
                 Padding="{StaticResource SongListViewPadding}"
+                Margin="{StaticResource SongListViewMargin}"
                 ItemContainerStyle="{StaticResource GenrePageGridViewItemStyle}">
                 <GridView.ItemsPanel>
                     <ItemsPanelTemplate>

--- a/src/Nagi.WinUI/Pages/GenreViewPage.xaml
+++ b/src/Nagi.WinUI/Pages/GenreViewPage.xaml
@@ -133,6 +133,7 @@
                                    Foreground="{ThemeResource TextFillColorSecondary}"
                                    Text="{x:Bind ViewModel.TotalItemsText, Mode=OneWay}"
                                    Visibility="{x:Bind ViewModel.HasSelectedSongs, Mode=OneWay, Converter={StaticResource InverseBooleanToVisibilityConverter}}" />
+                        <uicontrols:PaginationControl ViewModel="{x:Bind ViewModel}" />
                     </StackPanel>
                     <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
                         <!-- Search functionality -->
@@ -218,6 +219,7 @@
             x:Name="SongsListView"
             Grid.Row="1"
             Padding="{StaticResource SongListViewPadding}"
+            Margin="{StaticResource SongListViewMargin}"
             IsItemClickEnabled="True"
             ItemContainerStyle="{StaticResource SongListViewPageListViewItemStyle}"
             ItemsSource="{x:Bind ViewModel.Songs, Mode=OneWay}"
@@ -225,12 +227,6 @@
             SelectionMode="Extended"
             ContainerContentChanging="OnSongsListViewContainerContentChanging"
             DoubleTapped="SongsListView_DoubleTapped">
-            <ListView.Footer>
-                <uicontrols:PaginationControl
-                    ViewModel="{x:Bind ViewModel}"
-                    HorizontalAlignment="Right"
-                    Margin="0,24,24,16" />
-            </ListView.Footer>
             <ListView.ItemTemplate>
                 <DataTemplate x:DataType="models:Song">
                     <Grid Height="54" ColumnSpacing="12" Background="Transparent">

--- a/src/Nagi.WinUI/Pages/LibraryPage.xaml
+++ b/src/Nagi.WinUI/Pages/LibraryPage.xaml
@@ -121,6 +121,7 @@
                     Foreground="{ThemeResource TextFillColorSecondary}"
                     Text="{x:Bind ViewModel.TotalItemsText, Mode=OneWay}"
                     Visibility="{x:Bind ViewModel.HasSelectedSongs, Mode=OneWay, Converter={StaticResource InverseBooleanToVisibilityConverter}}" />
+                <uicontrols:PaginationControl ViewModel="{x:Bind ViewModel}" />
             </StackPanel>
 
             <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
@@ -209,6 +210,7 @@
             x:Name="SongsListView"
             Grid.Row="1"
             Padding="{StaticResource SongListViewPadding}"
+            Margin="{StaticResource SongListViewMargin}"
             IsItemClickEnabled="True"
             ItemContainerStyle="{StaticResource SongListViewPageListViewItemStyle}"
             ItemsSource="{x:Bind ViewModel.Songs, Mode=OneWay}"
@@ -216,12 +218,6 @@
             SelectionMode="Extended"
             ContainerContentChanging="OnSongsListViewContainerContentChanging"
             DoubleTapped="SongsListView_DoubleTapped">
-            <ListView.Footer>
-                <uicontrols:PaginationControl
-                    ViewModel="{x:Bind ViewModel}"
-                    HorizontalAlignment="Right"
-                    Margin="0,24,24,16" />
-            </ListView.Footer>
             <ListView.ItemTemplate>
                 <DataTemplate x:DataType="models:Song">
                     <Grid Height="54" ColumnSpacing="12" Background="Transparent">

--- a/src/Nagi.WinUI/Pages/LyricsPage.xaml
+++ b/src/Nagi.WinUI/Pages/LyricsPage.xaml
@@ -35,18 +35,29 @@
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
-        <TextBlock
+        <Grid
             Grid.Row="0"
-            Margin="0,32,0,8"
-            Style="{StaticResource TitleTextBlockStyle}"
-            Text="{x:Bind ViewModel.SongTitle, Mode=OneWay}"
-            Foreground="{StaticResource AppPrimaryColorBrush}"
-            FontWeight="SemiBold"
-            HorizontalAlignment="Center"
-            TextTrimming="CharacterEllipsis"
-            TextWrapping="NoWrap"
-            MaxLines="1"
-            MaxWidth="1200" />
+            Margin="24,32,24,8">
+            <TextBlock
+                Style="{StaticResource TitleTextBlockStyle}"
+                Text="{x:Bind ViewModel.SongTitle, Mode=OneWay}"
+                Foreground="{StaticResource AppPrimaryColorBrush}"
+                FontWeight="SemiBold"
+                HorizontalAlignment="Center"
+                TextTrimming="CharacterEllipsis"
+                TextWrapping="NoWrap"
+                MaxLines="1"
+                MaxWidth="1200" />
+            <Button
+                HorizontalAlignment="Right"
+                VerticalAlignment="Center"
+                Style="{StaticResource SubtleButtonStyle}"
+                IsEnabled="{x:Bind ViewModel.CanEditLyrics, Mode=OneWay}"
+                Click="EditLyricsButton_Click"
+                ToolTipService.ToolTip="{x:Bind resources:Strings.LyricsPage_EditLyrics_ToolTip, Mode=OneTime}">
+                <FontIcon Glyph="&#xE70F;" />
+            </Button>
+        </Grid>
 
         <ProgressBar
             x:Name="LyricsProgressBar"

--- a/src/Nagi.WinUI/Pages/LyricsPage.xaml.cs
+++ b/src/Nagi.WinUI/Pages/LyricsPage.xaml.cs
@@ -95,6 +95,62 @@ public sealed partial class LyricsPage : Page
         }
     }
 
+    private async void EditLyricsButton_Click(object sender, RoutedEventArgs e)
+    {
+        var originalLyrics = ViewModel.EditableLyrics;
+        var editor = new TextBox
+        {
+            Text = originalLyrics,
+            PlaceholderText = Nagi.WinUI.Resources.Strings.LyricsPage_EditLyrics_Placeholder,
+            AcceptsReturn = true,
+            TextWrapping = TextWrapping.Wrap,
+            MinWidth = 520,
+            Height = 360
+        };
+        ScrollViewer.SetVerticalScrollBarVisibility(editor, ScrollBarVisibility.Auto);
+        var dialog = new ContentDialog
+        {
+            Title = Nagi.WinUI.Resources.Strings.LyricsPage_EditLyrics_Title,
+            Content = editor,
+            PrimaryButtonText = Nagi.WinUI.Resources.Strings.LyricsPage_EditLyrics_Save,
+            SecondaryButtonText = ViewModel.CanRemoveLyrics
+                ? Nagi.WinUI.Resources.Strings.LyricsPage_EditLyrics_Remove
+                : string.Empty,
+            CloseButtonText = Nagi.WinUI.Resources.Strings.Generic_Cancel,
+            DefaultButton = ContentDialogButton.Primary,
+            XamlRoot = XamlRoot
+        };
+
+        void UpdateSaveButton() => dialog.IsPrimaryButtonEnabled =
+            !string.IsNullOrWhiteSpace(editor.Text) && editor.Text != originalLyrics;
+
+        editor.TextChanged += (_, _) => UpdateSaveButton();
+        UpdateSaveButton();
+        DialogThemeHelper.ApplyThemeOverrides(dialog);
+
+        try
+        {
+            var result = await dialog.ShowAsync();
+            if (result == ContentDialogResult.Primary)
+                await ViewModel.SaveLyricsAsync(editor.Text);
+            else if (result == ContentDialogResult.Secondary)
+                await ViewModel.RemoveLyricsAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to update lyrics.");
+            var errorDialog = new ContentDialog
+            {
+                Title = Nagi.WinUI.Resources.Strings.LyricsPage_EditLyrics_Error_Title,
+                Content = Nagi.WinUI.Resources.Strings.LyricsPage_EditLyrics_Error_Message,
+                CloseButtonText = Nagi.WinUI.Resources.Strings.Generic_OK,
+                XamlRoot = XamlRoot
+            };
+            DialogThemeHelper.ApplyThemeOverrides(errorDialog);
+            await errorDialog.ShowAsync();
+        }
+    }
+
     private void OnPageUnloaded(object sender, RoutedEventArgs e)
     {
         _isUnloaded = true;

--- a/src/Nagi.WinUI/Pages/PlaylistPage.xaml
+++ b/src/Nagi.WinUI/Pages/PlaylistPage.xaml
@@ -220,6 +220,7 @@
                 IsItemClickEnabled="True"
                 ItemClick="PlaylistsGridView_ItemClick"
                 Padding="{StaticResource SongListViewPadding}"
+                Margin="{StaticResource SongListViewMargin}"
                 ItemContainerStyle="{StaticResource PlaylistPageGridViewItemStyle}"
                 ItemsSource="{x:Bind ViewModel.Playlists, Mode=OneWay}"
                 SelectionMode="None"

--- a/src/Nagi.WinUI/Pages/PlaylistSongViewPage.xaml
+++ b/src/Nagi.WinUI/Pages/PlaylistSongViewPage.xaml
@@ -241,6 +241,7 @@
                   SelectionMode="Extended"
                   IsItemClickEnabled="True"
                   Padding="{StaticResource SongListViewPadding}"
+                  Margin="{StaticResource SongListViewMargin}"
                   ItemsSource="{x:Bind ViewModel.Songs, Mode=OneWay}"
                   ItemContainerStyle="{StaticResource SongListViewPageListViewItemStyle}"
                   CanDragItems="{x:Bind ViewModel.IsReorderingEnabled, Mode=OneWay}"

--- a/src/Nagi.WinUI/Pages/SettingsPage.xaml
+++ b/src/Nagi.WinUI/Pages/SettingsPage.xaml
@@ -449,6 +449,17 @@
                         IsOn="{x:Bind ViewModel.IsVolumeNormalizationEnabled, Mode=TwoWay}" />
                 </controls:SettingsCard>
 
+                <controls:SettingsCard
+                    Header="{x:Bind resources:Strings.SettingsPage_WasapiExclusive_Header, Mode=OneTime}"
+                    Description="{x:Bind resources:Strings.SettingsPage_WasapiExclusive_Description, Mode=OneTime}">
+                    <controls:SettingsCard.HeaderIcon>
+                        <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE995;" />
+                    </controls:SettingsCard.HeaderIcon>
+                    <ToggleSwitch
+                        HorizontalAlignment="Right"
+                        IsOn="{x:Bind ViewModel.IsWasapiExclusiveModeEnabled, Mode=TwoWay}" />
+                </controls:SettingsCard>
+
                 <controls:SettingsExpander
                     Header="{x:Bind resources:Strings.SettingsPage_FadeOnPlayPause_Header, Mode=OneTime}"
                     Description="{x:Bind resources:Strings.SettingsPage_FadeOnPlayPause_Description, Mode=OneTime}">

--- a/src/Nagi.WinUI/Pages/SmartPlaylistSongViewPage.xaml
+++ b/src/Nagi.WinUI/Pages/SmartPlaylistSongViewPage.xaml
@@ -164,6 +164,7 @@
                                Foreground="{ThemeResource TextFillColorSecondary}" VerticalAlignment="Center"
                                FontSize="13"
                                Visibility="{x:Bind ViewModel.HasSelectedSongs, Mode=OneWay, Converter={StaticResource InverseBooleanToVisibilityConverter}}" />
+                    <uicontrols:PaginationControl ViewModel="{x:Bind ViewModel}" />
                 </StackPanel>
 
                 <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
@@ -298,6 +299,7 @@
                   SelectionMode="Extended"
                   IsItemClickEnabled="True"
                   Padding="{StaticResource SongListViewPadding}"
+                  Margin="{StaticResource SongListViewMargin}"
                   ItemsSource="{x:Bind ViewModel.Songs, Mode=OneWay}"
                   ItemContainerStyle="{StaticResource SongListViewPageListViewItemStyle}"
                   SelectionChanged="SongsListView_SelectionChanged"
@@ -306,12 +308,6 @@
                   CanReorderItems="False"
                   AllowDrop="False"
                   DoubleTapped="SongsListView_DoubleTapped">
-            <ListView.Footer>
-                <uicontrols:PaginationControl
-                    ViewModel="{x:Bind ViewModel}"
-                    HorizontalAlignment="Right"
-                    Margin="0,24,24,16" />
-            </ListView.Footer>
             <ListView.ItemTemplate>
                 <DataTemplate x:DataType="models:Song">
                     <Grid Height="54" ColumnSpacing="12" Background="Transparent">

--- a/src/Nagi.WinUI/Resources/Strings.cs
+++ b/src/Nagi.WinUI/Resources/Strings.cs
@@ -635,6 +635,8 @@ public static class Strings
     public static string SettingsPage_Section_Player => GetString("SettingsPage_Section_Player");
     public static string SettingsPage_VolumeNormalization_Header => GetString("SettingsPage_VolumeNormalization_Header");
     public static string SettingsPage_VolumeNormalization_Description => GetString("SettingsPage_VolumeNormalization_Description");
+    public static string SettingsPage_WasapiExclusive_Header => GetString("SettingsPage_WasapiExclusive_Header");
+    public static string SettingsPage_WasapiExclusive_Description => GetString("SettingsPage_WasapiExclusive_Description");
     public static string SettingsPage_FadeOnPlayPause_Header => GetString("SettingsPage_FadeOnPlayPause_Header");
     public static string SettingsPage_FadeOnPlayPause_Description => GetString("SettingsPage_FadeOnPlayPause_Description");
     public static string SettingsPage_FadeInDuration_Header => GetString("SettingsPage_FadeInDuration_Header");

--- a/src/Nagi.WinUI/Resources/Strings.cs
+++ b/src/Nagi.WinUI/Resources/Strings.cs
@@ -557,6 +557,13 @@ public static class Strings
     public static string LibraryPage_EmptyState_Subtitle => GetString("LibraryPage_EmptyState_Subtitle");
     public static string LyricsPage_NoLyrics_Title => GetString("LyricsPage_NoLyrics_Title");
     public static string LyricsPage_NoLyrics_Subtitle => GetString("LyricsPage_NoLyrics_Subtitle");
+    public static string LyricsPage_EditLyrics_ToolTip => GetString("LyricsPage_EditLyrics_ToolTip");
+    public static string LyricsPage_EditLyrics_Title => GetString("LyricsPage_EditLyrics_Title");
+    public static string LyricsPage_EditLyrics_Placeholder => GetString("LyricsPage_EditLyrics_Placeholder");
+    public static string LyricsPage_EditLyrics_Save => GetString("LyricsPage_EditLyrics_Save");
+    public static string LyricsPage_EditLyrics_Remove => GetString("LyricsPage_EditLyrics_Remove");
+    public static string LyricsPage_EditLyrics_Error_Title => GetString("LyricsPage_EditLyrics_Error_Title");
+    public static string LyricsPage_EditLyrics_Error_Message => GetString("LyricsPage_EditLyrics_Error_Message");
     public static string OnboardingPage_Welcome_Title => GetString("OnboardingPage_Welcome_Title");
     public static string OnboardingPage_AddFolderButton_ToolTip => GetString("OnboardingPage_AddFolderButton_ToolTip");
     public static string OnboardingPage_AddFolderButton_Content => GetString("OnboardingPage_AddFolderButton_Content");

--- a/src/Nagi.WinUI/Resources/Strings.resx
+++ b/src/Nagi.WinUI/Resources/Strings.resx
@@ -1604,6 +1604,12 @@ Error: {1}</value>
   <data name="SettingsPage_VolumeNormalization_Description" xml:space="preserve">
     <value>Automatically adjust volume to the standard level (-14 LUFS) to avoid sudden loudness changes.</value>
   </data>
+  <data name="SettingsPage_WasapiExclusive_Header" xml:space="preserve">
+    <value>WASAPI exclusive mode</value>
+  </data>
+  <data name="SettingsPage_WasapiExclusive_Description" xml:space="preserve">
+    <value>Give Nagi exclusive control of the Windows audio device. Other apps may be silent. Restart Nagi after changing this setting.</value>
+  </data>
   <data name="SettingsPage_FadeOnPlayPause_Header" xml:space="preserve">
     <value>Fade on Play / Pause</value>
   </data>

--- a/src/Nagi.WinUI/Resources/Strings.resx
+++ b/src/Nagi.WinUI/Resources/Strings.resx
@@ -1388,6 +1388,27 @@ Error: {1}</value>
   <data name="LyricsPage_NoLyrics_Subtitle" xml:space="preserve">
     <value>Try another song</value>
   </data>
+  <data name="LyricsPage_EditLyrics_ToolTip" xml:space="preserve">
+    <value>Edit or replace lyrics</value>
+  </data>
+  <data name="LyricsPage_EditLyrics_Title" xml:space="preserve">
+    <value>Edit lyrics</value>
+  </data>
+  <data name="LyricsPage_EditLyrics_Placeholder" xml:space="preserve">
+    <value>Paste plain text or timestamped LRC lyrics</value>
+  </data>
+  <data name="LyricsPage_EditLyrics_Save" xml:space="preserve">
+    <value>Save</value>
+  </data>
+  <data name="LyricsPage_EditLyrics_Remove" xml:space="preserve">
+    <value>Remove saved lyrics</value>
+  </data>
+  <data name="LyricsPage_EditLyrics_Error_Title" xml:space="preserve">
+    <value>Lyrics could not be updated</value>
+  </data>
+  <data name="LyricsPage_EditLyrics_Error_Message" xml:space="preserve">
+    <value>Nagi could not save the lyrics. Check the log for details and try again.</value>
+  </data>
   <data name="OnboardingPage_Welcome_Title" xml:space="preserve">
     <value>Welcome to Nagi</value>
   </data>

--- a/src/Nagi.WinUI/Services/Implementations/LibVlcAudioPlayerService.cs
+++ b/src/Nagi.WinUI/Services/Implementations/LibVlcAudioPlayerService.cs
@@ -25,6 +25,7 @@ public sealed class LibVlcAudioPlayerService : IAudioPlayer, IDisposable
 
     private readonly IAppInfoService _appInfoService;
     private readonly IDispatcherService _dispatcherService;
+    private readonly ISettingsService _settingsService;
     private readonly ILogger<LibVlcAudioPlayerService> _logger;
     private readonly CancellationTokenSource _disposeCts = new();
     private readonly SemaphoreSlim _vlcOperationLock = new(1, 1);
@@ -71,10 +72,12 @@ public sealed class LibVlcAudioPlayerService : IAudioPlayer, IDisposable
     public LibVlcAudioPlayerService(
         IDispatcherService dispatcherService,
         IAppInfoService appInfoService,
+        ISettingsService settingsService,
         ILogger<LibVlcAudioPlayerService> logger)
     {
         _dispatcherService = dispatcherService ?? throw new ArgumentNullException(nameof(dispatcherService));
         _appInfoService = appInfoService ?? throw new ArgumentNullException(nameof(appInfoService));
+        _settingsService = settingsService ?? throw new ArgumentNullException(nameof(settingsService));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -124,7 +127,8 @@ public sealed class LibVlcAudioPlayerService : IAudioPlayer, IDisposable
 
             try
             {
-                InitializeLibVlcCore();
+                var useWasapiExclusive = await _settingsService.GetWasapiExclusiveModeEnabledAsync().ConfigureAwait(false);
+                InitializeLibVlcCore(useWasapiExclusive);
                 tcs.SetResult();
             }
             catch (Exception ex)
@@ -140,7 +144,7 @@ public sealed class LibVlcAudioPlayerService : IAudioPlayer, IDisposable
         }
     }
 
-    private void InitializeLibVlcCore()
+    private void InitializeLibVlcCore(bool useWasapiExclusive)
     {
         _logger.LogDebug("Initializing LibVLC core (deferred).");
 
@@ -152,10 +156,11 @@ public sealed class LibVlcAudioPlayerService : IAudioPlayer, IDisposable
 
         // LibVLC explicitly does not guarantee compatibility for constructor options.
         // Keep only the two behaviors that currently lack a suitable public LibVLC API.
-        var vlcOptions = new[] { "--no-video", "--no-volume-save" };
+        var vlcOptions = new List<string> { "--no-video", "--no-volume-save" };
+        if (useWasapiExclusive) vlcOptions.Add("--wasapi-exclusive");
 
         _logger.LogDebug("Initializing LibVLC with options: {VlcOptions}", string.Join(" ", vlcOptions));
-        _libVlc = new LibVLC(false, vlcOptions);
+        _libVlc = new LibVLC(false, vlcOptions.ToArray());
 
         // Subscribe before MediaPlayer construction so native audio-output diagnostics are captured.
         _libVlc.Log += OnLibVlcLog;

--- a/src/Nagi.WinUI/Services/Implementations/SettingsService.cs
+++ b/src/Nagi.WinUI/Services/Implementations/SettingsService.cs
@@ -64,6 +64,7 @@ public class SettingsService : IUISettingsService, IDisposable
     private const string RememberPaneStateEnabledKey = "RememberPaneStateEnabled";
     private const string LastPaneOpenKey = "LastPaneOpen";
     private const string VolumeNormalizationEnabledKey = "VolumeNormalizationEnabled";
+    private const string WasapiExclusiveModeEnabledKey = "WasapiExclusiveModeEnabled";
     private const string FadeOnPlayPauseEnabledKey = "FadeOnPlayPauseEnabled";
     private const string AccentColorKey = "AccentColor";
     private const string LyricsServiceProvidersKey = "LyricsServiceProviders";
@@ -174,6 +175,7 @@ public class SettingsService : IUISettingsService, IDisposable
             SetRememberWindowPositionEnabledAsync(SettingsDefaults.RememberWindowPositionEnabled),
             SetRememberPaneStateEnabledAsync(SettingsDefaults.RememberPaneStateEnabled),
             SetVolumeNormalizationEnabledAsync(SettingsDefaults.VolumeNormalizationEnabled),
+            SetWasapiExclusiveModeEnabledAsync(SettingsDefaults.WasapiExclusiveModeEnabled),
             SetFadeOnPlayPauseEnabledAsync(SettingsDefaults.FadeOnPlayPauseEnabled),
             SetFadeInDurationMsAsync(SettingsDefaults.DefaultFadeInDurationMs),
             SetFadeOutDurationMsAsync(SettingsDefaults.DefaultFadeOutDurationMs),
@@ -1088,6 +1090,12 @@ public class SettingsService : IUISettingsService, IDisposable
         return SetValueAndNotifyAsync(VolumeNormalizationEnabledKey, isEnabled, SettingsDefaults.VolumeNormalizationEnabled,
             VolumeNormalizationEnabledChanged);
     }
+
+    public Task<bool> GetWasapiExclusiveModeEnabledAsync() =>
+        Task.FromResult(GetValue(WasapiExclusiveModeEnabledKey, SettingsDefaults.WasapiExclusiveModeEnabled));
+
+    public Task SetWasapiExclusiveModeEnabledAsync(bool isEnabled) =>
+        SetValueAsync(WasapiExclusiveModeEnabledKey, isEnabled);
 
     public Task<bool> GetFadeOnPlayPauseEnabledAsync() => Task.FromResult(GetValue(FadeOnPlayPauseEnabledKey, SettingsDefaults.FadeOnPlayPauseEnabled));
 

--- a/src/Nagi.WinUI/Services/SettingsDefaults.cs
+++ b/src/Nagi.WinUI/Services/SettingsDefaults.cs
@@ -40,6 +40,7 @@ public static class SettingsDefaults
     public const bool RememberWindowPositionEnabled = false;
     public const bool RememberPaneStateEnabled = true;
     public const bool VolumeNormalizationEnabled = false;
+    public const bool WasapiExclusiveModeEnabled = false;
     public const bool FadeOnPlayPauseEnabled = false;
     public const int DefaultFadeInDurationMs = 200;
     public const int DefaultFadeOutDurationMs = 150;

--- a/src/Nagi.WinUI/Styles/Colors.xaml
+++ b/src/Nagi.WinUI/Styles/Colors.xaml
@@ -54,8 +54,9 @@
     <Thickness x:Key="PageHeaderMarginIndented">24,0,24,24</Thickness>
 
     <!-- ListView/GridView Padding -->
-    <Thickness x:Key="SongListViewPadding">24,0,24,132</Thickness>
-    <Thickness x:Key="SongListViewPaddingNoHorizontal">0,0,0,132</Thickness>
+    <Thickness x:Key="SongListViewPadding">24,0,24,0</Thickness>
+    <Thickness x:Key="SongListViewPaddingNoHorizontal">0</Thickness>
+    <Thickness x:Key="SongListViewMargin">0,0,0,132</Thickness>
 
     <!-- Search Box Sizing -->
     <x:Double x:Key="SearchBoxExpandedWidth">300</x:Double>

--- a/src/Nagi.WinUI/ViewModels/AlbumViewModel.cs
+++ b/src/Nagi.WinUI/ViewModels/AlbumViewModel.cs
@@ -89,8 +89,8 @@ public partial class AlbumViewModel : PagedListViewModelBase<Album>
     protected override async Task<PagedResult<Album>> LoadPageItemsAsync(int pageNumber, int pageSize, CancellationToken token)
     {
         var pagedResult = IsSearchActive
-            ? await _libraryService.SearchAlbumsPagedAsync(SearchTerm, pageNumber, pageSize)
-            : await _libraryService.GetAllAlbumsPagedAsync(pageNumber, pageSize, CurrentSortOrder);
+            ? await _libraryService.SearchAlbumsPagedAsync(SearchTerm, pageNumber, pageSize, token)
+            : await _libraryService.GetAllAlbumsPagedAsync(pageNumber, pageSize, CurrentSortOrder, token);
 
         token.ThrowIfCancellationRequested();
 

--- a/src/Nagi.WinUI/ViewModels/AlbumViewViewModel.cs
+++ b/src/Nagi.WinUI/ViewModels/AlbumViewViewModel.cs
@@ -77,7 +77,8 @@ public partial class AlbumViewViewModel : SongListViewModelBase
         else
             result = await _libraryReader.GetSongsByAlbumIdPagedAsync(_albumId, pageNumber, pageSize, sortOrder, cancellationToken);
 
-        if (pageNumber == 1) UpdateAlbumDetails(result);
+        if (pageNumber == 1)
+            _dispatcherService.TryEnqueue(() => UpdateAlbumDetails(result));
 
         return result;
     }
@@ -207,7 +208,9 @@ public partial class AlbumViewViewModel : SongListViewModelBase
     {
         try
         {
-            var duration = await _libraryReader.GetSearchTotalDurationInAlbumAsync(_albumId, searchTerm, cancellationToken);
+            var duration = await Task.Run(
+                () => _libraryReader.GetSearchTotalDurationInAlbumAsync(_albumId, searchTerm, cancellationToken),
+                cancellationToken).ConfigureAwait(false);
 
             if (!cancellationToken.IsCancellationRequested)
             {

--- a/src/Nagi.WinUI/ViewModels/ArtistViewModel.cs
+++ b/src/Nagi.WinUI/ViewModels/ArtistViewModel.cs
@@ -93,8 +93,8 @@ public partial class ArtistViewModel : PagedListViewModelBase<Artist>
     protected override async Task<PagedResult<Artist>> LoadPageItemsAsync(int pageNumber, int pageSize, CancellationToken token)
     {
         var pagedResult = IsSearchActive
-            ? await _libraryService.SearchArtistsPagedAsync(SearchTerm, pageNumber, pageSize)
-            : await _libraryService.GetAllArtistsPagedAsync(pageNumber, pageSize, CurrentSortOrder);
+            ? await _libraryService.SearchArtistsPagedAsync(SearchTerm, pageNumber, pageSize, token)
+            : await _libraryService.GetAllArtistsPagedAsync(pageNumber, pageSize, CurrentSortOrder, token);
 
         token.ThrowIfCancellationRequested();
         return pagedResult ?? new PagedResult<Artist>();

--- a/src/Nagi.WinUI/ViewModels/LyricsPageViewModel.cs
+++ b/src/Nagi.WinUI/ViewModels/LyricsPageViewModel.cs
@@ -41,6 +41,7 @@ public partial class LyricsPageViewModel : ObservableObject, IDisposable
     private LyricLine? _optimisticallySetLine;
     private DateTime _optimisticSetTimestamp;
     private ParsedLrc? _parsedLrc;
+    private Song? _currentSong;
 
     public LyricsPageViewModel(
         IMusicPlaybackService playbackService,
@@ -104,6 +105,10 @@ public partial class LyricsPageViewModel : ObservableObject, IDisposable
     [NotifyPropertyChangedFor(nameof(ShowNoLyricsMessage))]
     public partial bool IsLoading { get; set; }
 
+    [ObservableProperty] public partial bool CanEditLyrics { get; set; }
+    [ObservableProperty] public partial bool CanRemoveLyrics { get; set; }
+    [ObservableProperty] public partial string EditableLyrics { get; set; } = string.Empty;
+
     /// <summary>
     ///     True when the timed lyrics ListView should be displayed.
     /// </summary>
@@ -161,6 +166,23 @@ public partial class LyricsPageViewModel : ObservableObject, IDisposable
         await _playbackService.SeekAsync(targetTime);
     }
 
+    public async Task SaveLyricsAsync(string lyrics)
+    {
+        var song = _currentSong;
+        if (song is null || string.IsNullOrWhiteSpace(lyrics)) return;
+
+        await _lrcService.SaveLyricsAsync(song, lyrics).ConfigureAwait(false);
+        if (_currentSong?.Id == song.Id) await UpdateForTrack(song).ConfigureAwait(false);
+    }
+
+    public async Task RemoveLyricsAsync()
+    {
+        var song = _currentSong;
+        if (song is null || !await _lrcService.RemoveCachedLyricsAsync(song).ConfigureAwait(false)) return;
+
+        if (_currentSong?.Id == song.Id) await UpdateForTrack(song).ConfigureAwait(false);
+    }
+
     private void OnPlaybackServicePositionChanged()
     {
         UpdateCurrentLineFromPosition(_playbackService.CurrentPosition);
@@ -206,6 +228,8 @@ public partial class LyricsPageViewModel : ObservableObject, IDisposable
 
     private async Task UpdateForTrack(Song? song)
     {
+        _currentSong = song;
+
         // Cancel any previous lyrics fetch operation to prevent stale data when skipping songs
         CancellationToken cancellationToken;
         lock (_lyricsFetchLock)
@@ -230,6 +254,9 @@ public partial class LyricsPageViewModel : ObservableObject, IDisposable
             CurrentPosition = TimeSpan.Zero;
             HasLyrics = false;
             HasUnsyncedLyrics = false;
+            CanEditLyrics = false;
+            CanRemoveLyrics = song is not null && _lrcService.HasCachedLyrics(song);
+            EditableLyrics = string.Empty;
 
             if (song is null)
             {
@@ -277,6 +304,9 @@ public partial class LyricsPageViewModel : ObservableObject, IDisposable
                 {
                     if (cancellationToken.IsCancellationRequested || _isDisposed) return;
                     _parsedLrc = displayLrc;
+                    EditableLyrics = localLrc.RawUnsyncedLyrics ?? string.Empty;
+                    CanEditLyrics = true;
+                    CanRemoveLyrics = _lrcService.HasCachedLyrics(song);
                     LyricLines.AddRange(displayLrc.Lines);
                     HasLyrics = true;
                     IsLoading = false;
@@ -298,6 +328,9 @@ public partial class LyricsPageViewModel : ObservableObject, IDisposable
                     {
                         if (cancellationToken.IsCancellationRequested || _isDisposed) return;
                         _parsedLrc = displayLrc;
+                        EditableLyrics = fullSong.Lyrics;
+                        CanEditLyrics = true;
+                        CanRemoveLyrics = _lrcService.HasCachedLyrics(song);
                         LyricLines.AddRange(displayLrc.Lines);
                         HasLyrics = true;
                         IsLoading = false;
@@ -312,6 +345,9 @@ public partial class LyricsPageViewModel : ObservableObject, IDisposable
                 {
                     if (cancellationToken.IsCancellationRequested || _isDisposed) return;
                     UnsyncedLyricLines.AddRange(embeddedLines);
+                    EditableLyrics = fullSong.Lyrics;
+                    CanEditLyrics = true;
+                    CanRemoveLyrics = _lrcService.HasCachedLyrics(song);
                     HasUnsyncedLyrics = true;
                     IsLoading = false;
                 });
@@ -330,6 +366,9 @@ public partial class LyricsPageViewModel : ObservableObject, IDisposable
                 {
                     if (cancellationToken.IsCancellationRequested || _isDisposed) return;
                     _parsedLrc = displayLrc;
+                    EditableLyrics = parsedLrc.RawUnsyncedLyrics ?? string.Empty;
+                    CanEditLyrics = true;
+                    CanRemoveLyrics = _lrcService.HasCachedLyrics(song);
                     LyricLines.AddRange(displayLrc.Lines);
                     HasLyrics = true;
                     IsLoading = false;
@@ -346,6 +385,9 @@ public partial class LyricsPageViewModel : ObservableObject, IDisposable
                 {
                     if (cancellationToken.IsCancellationRequested || _isDisposed) return;
                     UnsyncedLyricLines.AddRange(unsyncedLines);
+                    EditableLyrics = parsedLrc.RawUnsyncedLyrics;
+                    CanEditLyrics = true;
+                    CanRemoveLyrics = _lrcService.HasCachedLyrics(song);
                     HasUnsyncedLyrics = true;
                     IsLoading = false;
                 });
@@ -356,6 +398,7 @@ public partial class LyricsPageViewModel : ObservableObject, IDisposable
                 _dispatcherService.TryEnqueue(() =>
                 {
                     if (cancellationToken.IsCancellationRequested || _isDisposed) return;
+                    CanEditLyrics = true;
                     IsLoading = false;
                 });
             }
@@ -368,7 +411,11 @@ public partial class LyricsPageViewModel : ObservableObject, IDisposable
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to fetch lyrics for track '{SongTitle}'", song.Title);
-            _dispatcherService.TryEnqueue(() => IsLoading = false);
+            _dispatcherService.TryEnqueue(() =>
+            {
+                CanEditLyrics = true;
+                IsLoading = false;
+            });
         }
     }
 

--- a/src/Nagi.WinUI/ViewModels/PagedListViewModelBase.cs
+++ b/src/Nagi.WinUI/ViewModels/PagedListViewModelBase.cs
@@ -252,21 +252,29 @@ public abstract partial class PagedListViewModelBase<TItem> : SearchableViewMode
             var pageToLoad = CurrentPage;
             var pageSize = SongsPerPage;
 
-            var auxTask = OnAuxiliaryLoadAsync(token);
-            var pageTask = LoadPageItemsAsync(pageToLoad, pageSize, token);
-            await Task.WhenAll(auxTask, pageTask).ConfigureAwait(false);
-            token.ThrowIfCancellationRequested();
-
-            var pagedResult = pageTask.Result;
-
-            // Past-end clamp: if the requested page exceeds the result set (e.g. items removed),
-            // jump back to the last valid page and refetch.
-            var totalPages = Math.Max(1, pagedResult.TotalPages);
-            if (pageToLoad > totalPages && pagedResult.TotalCount > 0)
+            // Microsoft.Data.Sqlite performs native I/O synchronously even through its async APIs.
+            // Keep that work off the UI thread so large-library searches and counts do not freeze
+            // the rest of the app.
+            var pagedResult = await Task.Run(async () =>
             {
-                pagedResult = await LoadPageItemsAsync(totalPages, pageSize, token).ConfigureAwait(false);
+                var auxTask = OnAuxiliaryLoadAsync(token);
+                var pageTask = LoadPageItemsAsync(pageToLoad, pageSize, token);
+                await Task.WhenAll(auxTask, pageTask).ConfigureAwait(false);
                 token.ThrowIfCancellationRequested();
-            }
+
+                var result = pageTask.Result;
+
+                // Past-end clamp: if the requested page exceeds the result set (e.g. items removed),
+                // jump back to the last valid page and refetch.
+                var totalPages = Math.Max(1, result.TotalPages);
+                if (pageToLoad > totalPages && result.TotalCount > 0)
+                {
+                    result = await LoadPageItemsAsync(totalPages, pageSize, token).ConfigureAwait(false);
+                    token.ThrowIfCancellationRequested();
+                }
+
+                return result;
+            }, token);
 
             ProcessPagedResult(pagedResult, token);
 

--- a/src/Nagi.WinUI/ViewModels/PlayerViewModel.cs
+++ b/src/Nagi.WinUI/ViewModels/PlayerViewModel.cs
@@ -59,6 +59,7 @@ public partial class PlayerViewModel : ObservableObject
 
     // Queue display update cancellation
     private CancellationTokenSource? _queueDisplayCts;
+    private Action? _cancelGlobalOperation;
 
     // Navigation re-entry guards
     private bool _isNavigatingToArtist;
@@ -138,6 +139,9 @@ public partial class PlayerViewModel : ObservableObject
     [ObservableProperty] public partial string GlobalOperationStatusMessage { get; set; }
     [ObservableProperty] public partial double GlobalOperationProgressValue { get; set; }
     [ObservableProperty] public partial bool IsGlobalOperationIndeterminate { get; set; }
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(CancelGlobalOperationCommand))]
+    public partial bool CanCancelGlobalOperation { get; set; }
     [ObservableProperty] public partial bool IsQueueViewVisible { get; set; }
 
     [ObservableProperty] public partial bool IsVolumeControlVisible { get; set; }
@@ -167,6 +171,28 @@ public partial class PlayerViewModel : ObservableObject
     };
 
     public string VolumeButtonToolTip => IsMuted ? Strings.Tooltip_Unmute : Strings.Tooltip_Mute;
+
+    public void SetGlobalOperationCancellation(Action? cancel)
+    {
+        Interlocked.Exchange(ref _cancelGlobalOperation, cancel);
+        CanCancelGlobalOperation = cancel is not null;
+    }
+
+    [RelayCommand(CanExecute = nameof(CanCancelGlobalOperation))]
+    private void CancelGlobalOperation()
+    {
+        var cancel = Interlocked.Exchange(ref _cancelGlobalOperation, null);
+        CanCancelGlobalOperation = false;
+
+        try
+        {
+            cancel?.Invoke();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to cancel the active global operation");
+        }
+    }
 
     partial void OnIsPlayingChanged(bool value)
     {
@@ -208,6 +234,8 @@ public partial class PlayerViewModel : ObservableObject
         _queueDisplayCts?.Cancel();
         _queueDisplayCts?.Dispose();
         _queueDisplayCts = null;
+        Interlocked.Exchange(ref _cancelGlobalOperation, null);
+        CanCancelGlobalOperation = false;
     }
 
 

--- a/src/Nagi.WinUI/ViewModels/SettingsViewModel.cs
+++ b/src/Nagi.WinUI/ViewModels/SettingsViewModel.cs
@@ -128,6 +128,7 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
     private bool _isInitializing;
     private bool _isLoaded;
     private CancellationTokenSource? _preampDebounceCts;
+    private CancellationTokenSource? _metadataRescanCts;
     private CancellationTokenSource? _replayGainScanCts;
     private CancellationTokenSource? _playerButtonSaveCts;
     private CancellationTokenSource? _navigationItemSaveCts;
@@ -431,8 +432,11 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
         }
         _preampDebounceCts?.Cancel();
         _preampDebounceCts?.Dispose();
+        _metadataRescanCts?.Cancel();
+        _metadataRescanCts?.Dispose();
         _replayGainScanCts?.Cancel();
         _replayGainScanCts?.Dispose();
+        _playerViewModel.SetGlobalOperationCancellation(null);
         _playerButtonSaveCts?.Cancel();
         _playerButtonSaveCts?.Dispose();
         _navigationItemSaveCts?.Cancel();
@@ -1308,22 +1312,33 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
 
         if (!confirmed) return;
 
+        _metadataRescanCts?.Cancel();
+        _metadataRescanCts?.Dispose();
+        _metadataRescanCts = new CancellationTokenSource();
+        var scanCts = _metadataRescanCts;
+
         _playerViewModel.IsGlobalOperationInProgress = true;
         _playerViewModel.GlobalOperationStatusMessage = Nagi.WinUI.Resources.Strings.Settings_Status_Rescan_Preparing;
         _playerViewModel.IsGlobalOperationIndeterminate = true;
+        _playerViewModel.SetGlobalOperationCancellation(scanCts.Cancel);
 
         try
         {
             var progress = new Progress<ScanProgress>(p =>
             {
                 _playerViewModel.GlobalOperationStatusMessage = p.StatusText;
-                _playerViewModel.IsGlobalOperationIndeterminate = p.IsIndeterminate || p.Percentage < 5;
+                _playerViewModel.IsGlobalOperationIndeterminate = p.IsIndeterminate;
                 _playerViewModel.GlobalOperationProgressValue = p.Percentage;
             });
 
-            await _libraryScanner.ForceRescanMetadataAsync(progress);
+            await _libraryScanner.ForceRescanMetadataAsync(progress, scanCts.Token);
+            if (scanCts.IsCancellationRequested) return;
 
             await _uiService.ShowMessageDialogAsync(Nagi.WinUI.Resources.Strings.Settings_Dialog_RescanComplete_Title, Nagi.WinUI.Resources.Strings.Settings_Dialog_RescanComplete_Content);
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogDebug("Metadata rescan was cancelled.");
         }
         catch (Exception ex)
         {
@@ -1332,8 +1347,12 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
         }
         finally
         {
+            _playerViewModel.SetGlobalOperationCancellation(null);
             _playerViewModel.IsGlobalOperationInProgress = false;
             _playerViewModel.IsGlobalOperationIndeterminate = false;
+            if (ReferenceEquals(_metadataRescanCts, scanCts))
+                _metadataRescanCts = null;
+            scanCts.Dispose();
         }
     }
 
@@ -1803,11 +1822,13 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
         _replayGainScanCts?.Cancel();
         _replayGainScanCts?.Dispose();
         _replayGainScanCts = new CancellationTokenSource();
-        var cancellationToken = _replayGainScanCts.Token;
+        var scanCts = _replayGainScanCts;
+        var cancellationToken = scanCts.Token;
 
         _playerViewModel.IsGlobalOperationInProgress = true;
         _playerViewModel.GlobalOperationStatusMessage = Nagi.WinUI.Resources.Strings.Settings_Status_VolumeNorm_Preparing;
         _playerViewModel.IsGlobalOperationIndeterminate = true;
+        _playerViewModel.SetGlobalOperationCancellation(scanCts.Cancel);
 
         try
         {
@@ -1831,6 +1852,7 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
         }
         finally
         {
+            _playerViewModel.SetGlobalOperationCancellation(null);
             _playerViewModel.IsGlobalOperationInProgress = false;
             _playerViewModel.IsGlobalOperationIndeterminate = false;
         }

--- a/src/Nagi.WinUI/ViewModels/SettingsViewModel.cs
+++ b/src/Nagi.WinUI/ViewModels/SettingsViewModel.cs
@@ -209,6 +209,7 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
         IsRememberWindowPositionEnabled = SettingsDefaults.RememberWindowPositionEnabled;
         IsRememberPaneStateEnabled = SettingsDefaults.RememberPaneStateEnabled;
         IsVolumeNormalizationEnabled = SettingsDefaults.VolumeNormalizationEnabled;
+        IsWasapiExclusiveModeEnabled = SettingsDefaults.WasapiExclusiveModeEnabled;
         IsFadeOnPlayPauseEnabled = SettingsDefaults.FadeOnPlayPauseEnabled;
         EqualizerPreamp = SettingsDefaults.EqualizerPreamp;
 
@@ -239,6 +240,7 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
     [ObservableProperty] public partial bool IsRememberWindowPositionEnabled { get; set; }
     [ObservableProperty] public partial bool IsRememberPaneStateEnabled { get; set; }
     [ObservableProperty] public partial bool IsVolumeNormalizationEnabled { get; set; }
+    [ObservableProperty] public partial bool IsWasapiExclusiveModeEnabled { get; set; }
     [ObservableProperty] public partial bool IsFadeOnPlayPauseEnabled { get; set; }
     [ObservableProperty] public partial double FadeInDurationMs { get; set; }
     [ObservableProperty] public partial double FadeOutDurationMs { get; set; }
@@ -511,6 +513,7 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
             var rememberPositionTask = _settingsService.GetRememberWindowPositionEnabledAsync();
             var rememberPaneTask = _settingsService.GetRememberPaneStateEnabledAsync();
             var volumeNormTask = _settingsService.GetVolumeNormalizationEnabledAsync();
+            var wasapiExclusiveTask = _settingsService.GetWasapiExclusiveModeEnabledAsync();
             var fadeTask = _settingsService.GetFadeOnPlayPauseEnabledAsync();
             var fadeInTask = _settingsService.GetFadeInDurationMsAsync();
             var fadeOutTask = _settingsService.GetFadeOutDurationMsAsync();
@@ -539,7 +542,7 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
                 playerAnimationTask, restorePlaybackTask, autoLaunchTask, startMinimizedTask,
                 hideToTrayTask, miniPlayerTask, trayFlyoutTask, onlineMetadataTask,
                 onlineLyricsTask, lyricsRomanizationTask, discordRpcTask, rememberWindowTask,
-                rememberPositionTask, rememberPaneTask, volumeNormTask, fadeTask, fadeInTask, fadeOutTask, lastFmCredsTask, lastFmAuthTokenTask,
+                rememberPositionTask, rememberPaneTask, volumeNormTask, wasapiExclusiveTask, fadeTask, fadeInTask, fadeOutTask, lastFmCredsTask, lastFmAuthTokenTask,
                 scrobblingTask, nowPlayingTask, accentColorTask, artistSplitTask, genreSplitTask, languageTask, lyricsProvidersTask, metadataProvidersTask,
                 playerMaterialTask, playerTintTask,
                 lbTokenTask, lbScrobblingTask, lbNowPlayingTask, lbServerUrlTask,
@@ -576,6 +579,7 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
             IsRememberWindowPositionEnabled = rememberPositionTask.Result;
             IsRememberPaneStateEnabled = rememberPaneTask.Result;
             IsVolumeNormalizationEnabled = volumeNormTask.Result;
+            IsWasapiExclusiveModeEnabled = wasapiExclusiveTask.Result;
             IsFadeOnPlayPauseEnabled = fadeTask.Result;
             FadeInDurationMs = fadeInTask.Result;
             FadeOutDurationMs = fadeOutTask.Result;
@@ -1741,6 +1745,12 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
         {
             _logger.LogError(ex, "Error toggling volume normalization to {Value}", value);
         }
+    }
+
+    partial void OnIsWasapiExclusiveModeEnabledChanged(bool value)
+    {
+        if (_isInitializing) return;
+        _ = _settingsService.SetWasapiExclusiveModeEnabledAsync(value);
     }
 
     async partial void OnIsFadeOnPlayPauseEnabledChanged(bool value)

--- a/src/Nagi.WinUI/ViewModels/SongListViewModelBase.cs
+++ b/src/Nagi.WinUI/ViewModels/SongListViewModelBase.cs
@@ -20,8 +20,8 @@ namespace Nagi.WinUI.ViewModels;
 
 /// <summary>
 ///     Base class for song list view models. Adds selection, playback commands, the
-///     full ID list (used for "Play All" without holding every <see cref="Song"/> in
-///     memory), and infinite-scroll auto-loading when
+///     full ID list (used for playback without holding every <see cref="Song"/> in memory),
+///     and infinite-scroll auto-loading when
 ///     <see cref="PagedListViewModelBase{TItem}.IsPaginationEnabled"/> is false.
 /// </summary>
 public abstract partial class SongListViewModelBase : PagedListViewModelBase<Song>
@@ -44,7 +44,7 @@ public abstract partial class SongListViewModelBase : PagedListViewModelBase<Son
     /// </summary>
     [ObservableProperty] public partial Guid? CurrentPlayingSongId { get; set; }
 
-    // For paged views, this holds all song IDs to enable "Play All" without loading all song objects into memory.
+    // Search loads defer this list until playback or a bulk selection actually needs it.
     protected List<Guid> _fullSongIdList = new();
 
     // Owned by the song-base's <see cref="LoadPageAsync"/> envelope (Next/Previous reload that skips
@@ -160,7 +160,7 @@ public abstract partial class SongListViewModelBase : PagedListViewModelBase<Son
             _stateLock.EnterReadLock();
             try
             {
-                return SelectionState.GetSelectedCount(_fullSongIdList.Count);
+                return SelectionState.GetSelectedCount(TotalItemCount);
             }
             finally
             {
@@ -209,6 +209,7 @@ public abstract partial class SongListViewModelBase : PagedListViewModelBase<Son
     protected override void OnSearchTermChangedInternal(string value)
     {
         if (HasSelectedSongs) DeselectAll();
+        ClearFullSongIds();
     }
 
     protected override async Task ExecuteSearchAsync(CancellationToken token)
@@ -226,14 +227,46 @@ public abstract partial class SongListViewModelBase : PagedListViewModelBase<Son
         return LoadSongsPagedAsync(pageNumber, pageSize, CurrentSortOrder, token);
     }
 
-    /// <summary>Run the full ID fetch (used by Play All) in parallel with the page query.</summary>
+    /// <summary>
+    ///     A new result set invalidates the playback ID cache. The complete list is intentionally
+    ///     loaded on demand so a 190k-song search does not execute and materialize the same broad
+    ///     query twice before its first page can be displayed.
+    /// </summary>
     protected override async Task OnAuxiliaryLoadAsync(CancellationToken token)
     {
+        if (IsSearchActive)
+        {
+            ClearFullSongIds();
+            return;
+        }
+
         var ids = await LoadAllSongIdsAsync(CurrentSortOrder, token).ConfigureAwait(false);
         token.ThrowIfCancellationRequested();
+
         _stateLock.EnterWriteLock();
         try { _fullSongIdList = ids; }
         finally { _stateLock.ExitWriteLock(); }
+    }
+
+    private void ClearFullSongIds()
+    {
+        _stateLock.EnterWriteLock();
+        try { _fullSongIdList = new List<Guid>(); }
+        finally { _stateLock.ExitWriteLock(); }
+    }
+
+    private async Task<List<Guid>> GetFullSongIdsAsync()
+    {
+        _stateLock.EnterReadLock();
+        try
+        {
+            if (_fullSongIdList.Count > 0) return _fullSongIdList.ToList();
+        }
+        finally { _stateLock.ExitReadLock(); }
+
+        var sortOrder = CurrentSortOrder;
+        return await Task.Run(() => LoadAllSongIdsAsync(sortOrder, CancellationToken.None))
+            .ConfigureAwait(false);
     }
 
     /// <summary>
@@ -299,7 +332,8 @@ public abstract partial class SongListViewModelBase : PagedListViewModelBase<Son
                 await Task.Delay(100, token);
                 if (token.IsCancellationRequested) break;
 
-                var pagedResult = await LoadSongsPagedAsync(nextPageToLoad, SongsPerPage, CurrentSortOrder, token);
+                var pagedResult = await Task.Run(
+                    () => LoadSongsPagedAsync(nextPageToLoad, SongsPerPage, CurrentSortOrder, token), token);
                 if (pagedResult == null) break;
 
                 ProcessPagedResult(pagedResult, token, true);
@@ -338,7 +372,8 @@ public abstract partial class SongListViewModelBase : PagedListViewModelBase<Son
             _pagedLoadCts = new CancellationTokenSource();
             var token = _pagedLoadCts.Token;
 
-            var pagedResult = await LoadSongsPagedAsync(pageNumber, SongsPerPage, CurrentSortOrder, token);
+            var pagedResult = await Task.Run(
+                () => LoadSongsPagedAsync(pageNumber, SongsPerPage, CurrentSortOrder, token), token);
             ProcessPagedResult(pagedResult, token);
         }
         catch (Exception ex)
@@ -426,34 +461,16 @@ public abstract partial class SongListViewModelBase : PagedListViewModelBase<Son
     [RelayCommand(CanExecute = nameof(CanExecutePlayAllCommands))]
     private async Task PlayAllSongsAsync()
     {
-        // Always use the pre-fetched full ID list for memory efficiency and consistency.
-        List<Guid> ids;
-        _stateLock.EnterReadLock();
-        try
-        {
-            ids = _fullSongIdList.ToList();
-        }
-        finally
-        {
-            _stateLock.ExitReadLock();
-        }
+        var ids = await GetFullSongIdsAsync();
+        if (ids.Count == 0) return;
         await _playbackService.PlayAsync(ids, 0, null, GetPlaybackContext());
     }
 
     [RelayCommand(CanExecute = nameof(CanExecutePlayAllCommands))]
     private async Task ShuffleAndPlayAllSongsAsync()
     {
-        // Always use the pre-fetched full ID list for memory efficiency and consistency.
-        List<Guid> ids;
-        _stateLock.EnterReadLock();
-        try
-        {
-            ids = _fullSongIdList.ToList();
-        }
-        finally
-        {
-            _stateLock.ExitReadLock();
-        }
+        var ids = await GetFullSongIdsAsync();
+        if (ids.Count == 0) return;
         await _playbackService.PlayAsync(ids, 0, true, GetPlaybackContext());
     }
 
@@ -462,19 +479,8 @@ public abstract partial class SongListViewModelBase : PagedListViewModelBase<Son
     {
         if (song == null) return;
 
-        // Always use the pre-fetched full ID list to find the song's position.
-        int startIndex;
-        List<Guid> ids;
-        _stateLock.EnterReadLock();
-        try
-        {
-            startIndex = _fullSongIdList.IndexOf(song.Id);
-            ids = _fullSongIdList.ToList();
-        }
-        finally
-        {
-            _stateLock.ExitReadLock();
-        }
+        var ids = await GetFullSongIdsAsync();
+        var startIndex = ids.IndexOf(song.Id);
 
         if (startIndex == -1)
         {
@@ -579,16 +585,7 @@ public abstract partial class SongListViewModelBase : PagedListViewModelBase<Son
 
     private bool CanExecutePlayAllCommands()
     {
-        // Always use the pre-fetched full ID list for consistency.
-        _stateLock.EnterReadLock();
-        try
-        {
-            return !IsLoading && _fullSongIdList.Any();
-        }
-        finally
-        {
-            _stateLock.ExitReadLock();
-        }
+        return !IsLoading && Songs.Any();
     }
 
     private bool CanExecuteSelectedSongsCommands()
@@ -618,12 +615,13 @@ public abstract partial class SongListViewModelBase : PagedListViewModelBase<Son
         UpdateSelectionDependentCommands();
     }
 
-    protected virtual Task<List<Guid>> GetCurrentSelectionIdsAsync()
+    protected virtual async Task<List<Guid>> GetCurrentSelectionIdsAsync()
     {
+        var ids = await GetFullSongIdsAsync();
         _stateLock.EnterReadLock();
         try
         {
-            return Task.FromResult(SelectionState.GetSelectedIds(_fullSongIdList).ToList());
+            return SelectionState.GetSelectedIds(ids).ToList();
         }
         finally
         {
@@ -743,6 +741,7 @@ public abstract partial class SongListViewModelBase : PagedListViewModelBase<Son
     {
         base.ResetState();
         SelectionState.DeselectAll();
+        ClearFullSongIds();
         CancelInflightPageLoad();
         _pagedLoadCts?.Cancel();
         _pagedLoadCts?.Dispose();

--- a/tests/Nagi.Core.Tests/LrcServiceTests.cs
+++ b/tests/Nagi.Core.Tests/LrcServiceTests.cs
@@ -194,6 +194,63 @@ public class LrcServiceTests
         result.Should().BeNull();
     }
 
+    [Fact]
+    public async Task SaveLyricsAsync_WritesIdentityBasedCacheAndUpdatesSong()
+    {
+        const string cacheRoot = @"C:\cache\lrc";
+        var song = new Song
+        {
+            Id = Guid.NewGuid(),
+            Title = "Song",
+            PrimaryArtistName = "Artist",
+            FilePath = @"C:\Music\Song.flac",
+            Album = new Album { Title = "Album" }
+        };
+        const string content = "[00:01.00]Correct lyrics";
+        _pathConfig.LrcCachePath.Returns(cacheRoot);
+        _fileSystem.Combine(Arg.Any<string[]>()).Returns(call => Path.Combine(call.Arg<string[]>()!));
+
+        await _lrcService.SaveLyricsAsync(song, content);
+
+        var expectedPath = Path.Combine(cacheRoot, FileNameHelper.GenerateLrcCacheFileName(
+            song.FilePath, song.PrimaryArtistName, song.Album.Title, song.Title));
+        await _fileSystem.Received(1).WriteAllTextAsync(expectedPath, content);
+        await _libraryWriter.Received(1).UpdateSongLrcPathAsync(song.Id, expectedPath);
+        song.LrcFilePath.Should().Be(expectedPath);
+    }
+
+    [Fact]
+    public async Task RemoveCachedLyricsAsync_DeletesOnlyManagedFileAndPreventsRedownload()
+    {
+        const string cacheRoot = @"C:\cache\lrc";
+        var cachedPath = Path.Combine(cacheRoot, "song.lrc");
+        var song = new Song { Id = Guid.NewGuid(), LrcFilePath = cachedPath };
+        _pathConfig.LrcCachePath.Returns(cacheRoot);
+        _fileSystem.FileExists(cachedPath).Returns(true);
+
+        var removed = await _lrcService.RemoveCachedLyricsAsync(song);
+
+        removed.Should().BeTrue();
+        _fileSystem.Received(1).DeleteFile(cachedPath);
+        await _libraryWriter.Received(1).UpdateSongLrcPathAsync(song.Id, null);
+        await _libraryWriter.Received(1).UpdateSongLyricsLastCheckedAsync(song.Id);
+        song.LrcFilePath.Should().BeNull();
+        song.LyricsLastCheckedUtc.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task RemoveCachedLyricsAsync_WithExternalSidecar_DoesNotDeleteFile()
+    {
+        var song = new Song { Id = Guid.NewGuid(), LrcFilePath = @"C:\Music\Song.lrc" };
+        _pathConfig.LrcCachePath.Returns(@"C:\cache\lrc");
+
+        var removed = await _lrcService.RemoveCachedLyricsAsync(song);
+
+        removed.Should().BeFalse();
+        _fileSystem.DidNotReceive().DeleteFile(Arg.Any<string>());
+        await _libraryWriter.DidNotReceive().UpdateSongLrcPathAsync(Arg.Any<Guid>(), Arg.Any<string?>());
+    }
+
     #endregion
 
     #region GetCurrentLine Tests


### PR DESCRIPTION
A focused pass over the current issue backlog.

- updates LibVLC nightlies for the upstream audio-device disconnect fix and adds opt-in WASAPI exclusive playback
- restores the full window on tray double-click
- keeps scrollbars above the player and moves pagination into the always-visible list headers
- allows saved/downloaded lyrics to be replaced or removed without deleting external sidecar files
- keeps large-library SQLite searches off the UI thread, avoids eagerly materializing every matching song ID, and makes metadata rescans cancellable with honest progress

Upstream VLC work:
- WASAPI exclusive: https://code.videolan.org/videolan/vlc/-/merge_requests/8606
- audio device changes: https://code.videolan.org/videolan/vlc/-/work_items/30009 / https://code.videolan.org/videolan/vlc/-/merge_requests/9726

Verified with:
- `dotnet build Nagi.sln --configuration Release --no-restore -p:Platform=x64`
- `dotnet test tests/Nagi.Core.Tests/Nagi.Core.Tests.csproj --configuration Release --no-build --no-restore` (837 passed)

Closes #100
Closes #129
Closes #130
Closes #131
Closes #132
Closes #133