### PR TITLE
fix: restore the window on tray double-click

### DIFF
--- a/src/Nagi.WinUI/Controls/TrayIconUserControl.xaml
+++ b/src/Nagi.WinUI/Controls/TrayIconUserControl.xaml
@@ -18,7 +18,7 @@
         IconSource="ms-appx:///Assets/AppLogo.ico"
         LeftClickCommand="{x:Bind ViewModel.ShowPopupCommand}"
         LeftClickCommandParameter="{Binding RelativeSource={RelativeSource Self}}"
-        NoLeftClickDelay="True"
+        DoubleClickCommand="{x:Bind ViewModel.RestoreWindowCommand}"
         ToolTipText="{x:Bind ViewModel.ToolTipText, Mode=OneWay}"
         ContextMenuMode="SecondWindow">
 


### PR DESCRIPTION
Keeps single-click flyout behavior and restores the full window on double-click.

Closes #132