### PR TITLE
feat: add WASAPI exclusive playback option

### DIFF
--- a/src/Nagi.Core/Services/Abstractions/ISettingsService.cs
+++ b/src/Nagi.Core/Services/Abstractions/ISettingsService.cs
@@ -333,6 +333,12 @@ public interface ISettingsService
     /// <param name="isEnabled">The preference to save.</param>
     Task SetVolumeNormalizationEnabledAsync(bool isEnabled);
 
+    /// <summary>Gets whether VLC should use WASAPI exclusive mode.</summary>
+    Task<bool> GetWasapiExclusiveModeEnabledAsync();
+
+    /// <summary>Sets whether VLC should use WASAPI exclusive mode.</summary>
+    Task SetWasapiExclusiveModeEnabledAsync(bool isEnabled);
+
     /// <summary>
     ///     Gets whether fade on play/pause is enabled.
     /// </summary>

--- a/src/Nagi.WinUI/App.xaml.cs
+++ b/src/Nagi.WinUI/App.xaml.cs
@@ -653,6 +653,7 @@ public partial class App : Application
         services.AddSingleton<IAudioPlayer>(provider =>
             new LibVlcAudioPlayerService(provider.GetRequiredService<IDispatcherService>(),
                 provider.GetRequiredService<IAppInfoService>(),
+                provider.GetRequiredService<ISettingsService>(),
                 provider.GetRequiredService<ILogger<LibVlcAudioPlayerService>>()));
         services.AddTransient<ITaskbarService>(provider =>
             new TaskbarService(

--- a/src/Nagi.WinUI/Pages/SettingsPage.xaml
+++ b/src/Nagi.WinUI/Pages/SettingsPage.xaml
@@ -449,6 +449,17 @@
                         IsOn="{x:Bind ViewModel.IsVolumeNormalizationEnabled, Mode=TwoWay}" />
                 </controls:SettingsCard>
 
+                <controls:SettingsCard
+                    Header="{x:Bind resources:Strings.SettingsPage_WasapiExclusive_Header, Mode=OneTime}"
+                    Description="{x:Bind resources:Strings.SettingsPage_WasapiExclusive_Description, Mode=OneTime}">
+                    <controls:SettingsCard.HeaderIcon>
+                        <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE995;" />
+                    </controls:SettingsCard.HeaderIcon>
+                    <ToggleSwitch
+                        HorizontalAlignment="Right"
+                        IsOn="{x:Bind ViewModel.IsWasapiExclusiveModeEnabled, Mode=TwoWay}" />
+                </controls:SettingsCard>
+
                 <controls:SettingsExpander
                     Header="{x:Bind resources:Strings.SettingsPage_FadeOnPlayPause_Header, Mode=OneTime}"
                     Description="{x:Bind resources:Strings.SettingsPage_FadeOnPlayPause_Description, Mode=OneTime}">

--- a/src/Nagi.WinUI/Resources/Strings.cs
+++ b/src/Nagi.WinUI/Resources/Strings.cs
@@ -635,6 +635,8 @@ public static class Strings
     public static string SettingsPage_Section_Player => GetString("SettingsPage_Section_Player");
     public static string SettingsPage_VolumeNormalization_Header => GetString("SettingsPage_VolumeNormalization_Header");
     public static string SettingsPage_VolumeNormalization_Description => GetString("SettingsPage_VolumeNormalization_Description");
+    public static string SettingsPage_WasapiExclusive_Header => GetString("SettingsPage_WasapiExclusive_Header");
+    public static string SettingsPage_WasapiExclusive_Description => GetString("SettingsPage_WasapiExclusive_Description");
     public static string SettingsPage_FadeOnPlayPause_Header => GetString("SettingsPage_FadeOnPlayPause_Header");
     public static string SettingsPage_FadeOnPlayPause_Description => GetString("SettingsPage_FadeOnPlayPause_Description");
     public static string SettingsPage_FadeInDuration_Header => GetString("SettingsPage_FadeInDuration_Header");

--- a/src/Nagi.WinUI/Resources/Strings.resx
+++ b/src/Nagi.WinUI/Resources/Strings.resx
@@ -1604,6 +1604,12 @@ Error: {1}</value>
   <data name="SettingsPage_VolumeNormalization_Description" xml:space="preserve">
     <value>Automatically adjust volume to the standard level (-14 LUFS) to avoid sudden loudness changes.</value>
   </data>
+  <data name="SettingsPage_WasapiExclusive_Header" xml:space="preserve">
+    <value>WASAPI exclusive mode</value>
+  </data>
+  <data name="SettingsPage_WasapiExclusive_Description" xml:space="preserve">
+    <value>Give Nagi exclusive control of the Windows audio device. Other apps may be silent. Restart Nagi after changing this setting.</value>
+  </data>
   <data name="SettingsPage_FadeOnPlayPause_Header" xml:space="preserve">
     <value>Fade on Play / Pause</value>
   </data>

--- a/src/Nagi.WinUI/Services/Implementations/LibVlcAudioPlayerService.cs
+++ b/src/Nagi.WinUI/Services/Implementations/LibVlcAudioPlayerService.cs
@@ -25,6 +25,7 @@ public sealed class LibVlcAudioPlayerService : IAudioPlayer, IDisposable
 
     private readonly IAppInfoService _appInfoService;
     private readonly IDispatcherService _dispatcherService;
+    private readonly ISettingsService _settingsService;
     private readonly ILogger<LibVlcAudioPlayerService> _logger;
     private readonly CancellationTokenSource _disposeCts = new();
     private readonly SemaphoreSlim _vlcOperationLock = new(1, 1);
@@ -71,10 +72,12 @@ public sealed class LibVlcAudioPlayerService : IAudioPlayer, IDisposable
     public LibVlcAudioPlayerService(
         IDispatcherService dispatcherService,
         IAppInfoService appInfoService,
+        ISettingsService settingsService,
         ILogger<LibVlcAudioPlayerService> logger)
     {
         _dispatcherService = dispatcherService ?? throw new ArgumentNullException(nameof(dispatcherService));
         _appInfoService = appInfoService ?? throw new ArgumentNullException(nameof(appInfoService));
+        _settingsService = settingsService ?? throw new ArgumentNullException(nameof(settingsService));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -124,7 +127,8 @@ public sealed class LibVlcAudioPlayerService : IAudioPlayer, IDisposable
 
             try
             {
-                InitializeLibVlcCore();
+                var useWasapiExclusive = await _settingsService.GetWasapiExclusiveModeEnabledAsync().ConfigureAwait(false);
+                InitializeLibVlcCore(useWasapiExclusive);
                 tcs.SetResult();
             }
             catch (Exception ex)
@@ -140,7 +144,7 @@ public sealed class LibVlcAudioPlayerService : IAudioPlayer, IDisposable
         }
     }
 
-    private void InitializeLibVlcCore()
+    private void InitializeLibVlcCore(bool useWasapiExclusive)
     {
         _logger.LogDebug("Initializing LibVLC core (deferred).");
 
@@ -152,10 +156,11 @@ public sealed class LibVlcAudioPlayerService : IAudioPlayer, IDisposable
 
         // LibVLC explicitly does not guarantee compatibility for constructor options.
         // Keep only the two behaviors that currently lack a suitable public LibVLC API.
-        var vlcOptions = new[] { "--no-video", "--no-volume-save" };
+        var vlcOptions = new List<string> { "--no-video", "--no-volume-save" };
+        if (useWasapiExclusive) vlcOptions.Add("--wasapi-exclusive");
 
         _logger.LogDebug("Initializing LibVLC with options: {VlcOptions}", string.Join(" ", vlcOptions));
-        _libVlc = new LibVLC(false, vlcOptions);
+        _libVlc = new LibVLC(false, vlcOptions.ToArray());
 
         // Subscribe before MediaPlayer construction so native audio-output diagnostics are captured.
         _libVlc.Log += OnLibVlcLog;

--- a/src/Nagi.WinUI/Services/Implementations/SettingsService.cs
+++ b/src/Nagi.WinUI/Services/Implementations/SettingsService.cs
@@ -64,6 +64,7 @@ public class SettingsService : IUISettingsService, IDisposable
     private const string RememberPaneStateEnabledKey = "RememberPaneStateEnabled";
     private const string LastPaneOpenKey = "LastPaneOpen";
     private const string VolumeNormalizationEnabledKey = "VolumeNormalizationEnabled";
+    private const string WasapiExclusiveModeEnabledKey = "WasapiExclusiveModeEnabled";
     private const string FadeOnPlayPauseEnabledKey = "FadeOnPlayPauseEnabled";
     private const string AccentColorKey = "AccentColor";
     private const string LyricsServiceProvidersKey = "LyricsServiceProviders";
@@ -174,6 +175,7 @@ public class SettingsService : IUISettingsService, IDisposable
             SetRememberWindowPositionEnabledAsync(SettingsDefaults.RememberWindowPositionEnabled),
             SetRememberPaneStateEnabledAsync(SettingsDefaults.RememberPaneStateEnabled),
             SetVolumeNormalizationEnabledAsync(SettingsDefaults.VolumeNormalizationEnabled),
+            SetWasapiExclusiveModeEnabledAsync(SettingsDefaults.WasapiExclusiveModeEnabled),
             SetFadeOnPlayPauseEnabledAsync(SettingsDefaults.FadeOnPlayPauseEnabled),
             SetFadeInDurationMsAsync(SettingsDefaults.DefaultFadeInDurationMs),
             SetFadeOutDurationMsAsync(SettingsDefaults.DefaultFadeOutDurationMs),
@@ -1088,6 +1090,12 @@ public class SettingsService : IUISettingsService, IDisposable
         return SetValueAndNotifyAsync(VolumeNormalizationEnabledKey, isEnabled, SettingsDefaults.VolumeNormalizationEnabled,
             VolumeNormalizationEnabledChanged);
     }
+
+    public Task<bool> GetWasapiExclusiveModeEnabledAsync() =>
+        Task.FromResult(GetValue(WasapiExclusiveModeEnabledKey, SettingsDefaults.WasapiExclusiveModeEnabled));
+
+    public Task SetWasapiExclusiveModeEnabledAsync(bool isEnabled) =>
+        SetValueAsync(WasapiExclusiveModeEnabledKey, isEnabled);
 
     public Task<bool> GetFadeOnPlayPauseEnabledAsync() => Task.FromResult(GetValue(FadeOnPlayPauseEnabledKey, SettingsDefaults.FadeOnPlayPauseEnabled));
 

--- a/src/Nagi.WinUI/Services/SettingsDefaults.cs
+++ b/src/Nagi.WinUI/Services/SettingsDefaults.cs
@@ -40,6 +40,7 @@ public static class SettingsDefaults
     public const bool RememberWindowPositionEnabled = false;
     public const bool RememberPaneStateEnabled = true;
     public const bool VolumeNormalizationEnabled = false;
+    public const bool WasapiExclusiveModeEnabled = false;
     public const bool FadeOnPlayPauseEnabled = false;
     public const int DefaultFadeInDurationMs = 200;
     public const int DefaultFadeOutDurationMs = 150;

--- a/src/Nagi.WinUI/ViewModels/SettingsViewModel.cs
+++ b/src/Nagi.WinUI/ViewModels/SettingsViewModel.cs
@@ -209,6 +209,7 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
         IsRememberWindowPositionEnabled = SettingsDefaults.RememberWindowPositionEnabled;
         IsRememberPaneStateEnabled = SettingsDefaults.RememberPaneStateEnabled;
         IsVolumeNormalizationEnabled = SettingsDefaults.VolumeNormalizationEnabled;
+        IsWasapiExclusiveModeEnabled = SettingsDefaults.WasapiExclusiveModeEnabled;
         IsFadeOnPlayPauseEnabled = SettingsDefaults.FadeOnPlayPauseEnabled;
         EqualizerPreamp = SettingsDefaults.EqualizerPreamp;
 
@@ -239,6 +240,7 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
     [ObservableProperty] public partial bool IsRememberWindowPositionEnabled { get; set; }
     [ObservableProperty] public partial bool IsRememberPaneStateEnabled { get; set; }
     [ObservableProperty] public partial bool IsVolumeNormalizationEnabled { get; set; }
+    [ObservableProperty] public partial bool IsWasapiExclusiveModeEnabled { get; set; }
     [ObservableProperty] public partial bool IsFadeOnPlayPauseEnabled { get; set; }
     [ObservableProperty] public partial double FadeInDurationMs { get; set; }
     [ObservableProperty] public partial double FadeOutDurationMs { get; set; }
@@ -511,6 +513,7 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
             var rememberPositionTask = _settingsService.GetRememberWindowPositionEnabledAsync();
             var rememberPaneTask = _settingsService.GetRememberPaneStateEnabledAsync();
             var volumeNormTask = _settingsService.GetVolumeNormalizationEnabledAsync();
+            var wasapiExclusiveTask = _settingsService.GetWasapiExclusiveModeEnabledAsync();
             var fadeTask = _settingsService.GetFadeOnPlayPauseEnabledAsync();
             var fadeInTask = _settingsService.GetFadeInDurationMsAsync();
             var fadeOutTask = _settingsService.GetFadeOutDurationMsAsync();
@@ -539,7 +542,7 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
                 playerAnimationTask, restorePlaybackTask, autoLaunchTask, startMinimizedTask,
                 hideToTrayTask, miniPlayerTask, trayFlyoutTask, onlineMetadataTask,
                 onlineLyricsTask, lyricsRomanizationTask, discordRpcTask, rememberWindowTask,
-                rememberPositionTask, rememberPaneTask, volumeNormTask, fadeTask, fadeInTask, fadeOutTask, lastFmCredsTask, lastFmAuthTokenTask,
+                rememberPositionTask, rememberPaneTask, volumeNormTask, wasapiExclusiveTask, fadeTask, fadeInTask, fadeOutTask, lastFmCredsTask, lastFmAuthTokenTask,
                 scrobblingTask, nowPlayingTask, accentColorTask, artistSplitTask, genreSplitTask, languageTask, lyricsProvidersTask, metadataProvidersTask,
                 playerMaterialTask, playerTintTask,
                 lbTokenTask, lbScrobblingTask, lbNowPlayingTask, lbServerUrlTask,
@@ -576,6 +579,7 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
             IsRememberWindowPositionEnabled = rememberPositionTask.Result;
             IsRememberPaneStateEnabled = rememberPaneTask.Result;
             IsVolumeNormalizationEnabled = volumeNormTask.Result;
+            IsWasapiExclusiveModeEnabled = wasapiExclusiveTask.Result;
             IsFadeOnPlayPauseEnabled = fadeTask.Result;
             FadeInDurationMs = fadeInTask.Result;
             FadeOutDurationMs = fadeOutTask.Result;
@@ -1741,6 +1745,12 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
         {
             _logger.LogError(ex, "Error toggling volume normalization to {Value}", value);
         }
+    }
+
+    partial void OnIsWasapiExclusiveModeEnabledChanged(bool value)
+    {
+        if (_isInitializing) return;
+        _ = _settingsService.SetWasapiExclusiveModeEnabledAsync(value);
     }
 
     async partial void OnIsFadeOnPlayPauseEnabledChanged(bool value)


### PR DESCRIPTION
Adds an opt-in, restart-required WASAPI exclusive toggle. It remains off by default.

Upstream: https://code.videolan.org/videolan/vlc/-/merge_requests/8606
Closes #100