### PR TITLE
fix: keep library navigation above the player

### DIFF
--- a/src/Nagi.WinUI/Pages/AlbumPage.xaml
+++ b/src/Nagi.WinUI/Pages/AlbumPage.xaml
@@ -122,6 +122,7 @@
                     FontSize="13"
                     Foreground="{ThemeResource TextFillColorSecondary}"
                     Text="{x:Bind ViewModel.TotalItemsText, Mode=OneWay}" />
+                <uicontrols:PaginationControl ViewModel="{x:Bind ViewModel}" />
             </StackPanel>
 
             <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
@@ -199,6 +200,7 @@
                 IsItemClickEnabled="True"
                 ItemClick="AlbumsGridView_ItemClick"
                 Padding="{StaticResource SongListViewPadding}"
+                Margin="{StaticResource SongListViewMargin}"
                 ItemContainerStyle="{StaticResource AlbumPageGridViewItemStyle}"
                 ItemsSource="{x:Bind ViewModel.Albums, Mode=OneWay}"
                 SelectionMode="None"
@@ -277,12 +279,6 @@
                         </Grid>
                     </DataTemplate>
                 </GridView.ItemTemplate>
-                <GridView.Footer>
-                    <uicontrols:PaginationControl
-                        ViewModel="{x:Bind ViewModel}"
-                        HorizontalAlignment="Right"
-                        Margin="0,24,24,16" />
-                </GridView.Footer>
             </GridView>
 
             <!-- Message shown when the library is empty -->

--- a/src/Nagi.WinUI/Pages/AlbumViewPage.xaml
+++ b/src/Nagi.WinUI/Pages/AlbumViewPage.xaml
@@ -155,6 +155,7 @@
                                Foreground="{ThemeResource TextFillColorSecondary}" VerticalAlignment="Center"
                                FontSize="13"
                                Visibility="{x:Bind ViewModel.HasSelectedSongs, Mode=OneWay, Converter={StaticResource InverseBooleanToVisibilityConverter}}" />
+                    <uicontrols:PaginationControl ViewModel="{x:Bind ViewModel}" />
                 </StackPanel>
 
                 <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
@@ -235,6 +236,7 @@
             Grid.Row="1"
             x:Name="GroupedSongsListView"
             Padding="{StaticResource SongListViewPadding}"
+            Margin="{StaticResource SongListViewMargin}"
             IsItemClickEnabled="True"
             ItemsSource="{x:Bind ViewModel.GroupedSongsFlat, Mode=OneWay}"
             SelectionChanged="GroupedSongsListView_SelectionChanged"
@@ -242,12 +244,6 @@
             ContainerContentChanging="OnSongsListViewContainerContentChanging"
             DoubleTapped="GroupedSongsListView_DoubleTapped"
             Visibility="{x:Bind ViewModel.IsGroupedByDisc, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
-            <ListView.Footer>
-                <uicontrols:PaginationControl
-                    ViewModel="{x:Bind ViewModel}"
-                    HorizontalAlignment="Right"
-                    Margin="0,24,24,16" />
-            </ListView.Footer>
             <ListView.ItemContainerStyleSelector>
                 <local:DiscGroupStyleSelector>
                     <local:DiscGroupStyleSelector.HeaderStyle>
@@ -318,6 +314,7 @@
             Grid.Row="1"
             x:Name="SongsListView"
             Padding="{StaticResource SongListViewPadding}"
+            Margin="{StaticResource SongListViewMargin}"
             IsItemClickEnabled="True"
             ItemContainerStyle="{StaticResource SongListViewPageListViewItemStyle}"
             ItemsSource="{x:Bind ViewModel.Songs, Mode=OneWay}"
@@ -326,12 +323,6 @@
             ContainerContentChanging="OnSongsListViewContainerContentChanging"
             DoubleTapped="SongsListView_DoubleTapped"
             Visibility="{x:Bind ViewModel.IsGroupedByDisc, Mode=OneWay, Converter={StaticResource InverseBooleanToVisibilityConverter}}">
-            <ListView.Footer>
-                <uicontrols:PaginationControl
-                    ViewModel="{x:Bind ViewModel}"
-                    HorizontalAlignment="Right"
-                    Margin="0,24,24,16" />
-            </ListView.Footer>
             <ListView.ItemTemplate>
                 <DataTemplate x:DataType="models:Song">
                     <Grid Height="54" ColumnSpacing="12" Background="Transparent">

--- a/src/Nagi.WinUI/Pages/ArtistPage.xaml
+++ b/src/Nagi.WinUI/Pages/ArtistPage.xaml
@@ -121,6 +121,7 @@
                     FontSize="13"
                     Foreground="{ThemeResource TextFillColorSecondary}"
                     Text="{x:Bind ViewModel.TotalItemsText, Mode=OneWay}" />
+                <uicontrols:PaginationControl ViewModel="{x:Bind ViewModel}" />
             </StackPanel>
 
             <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
@@ -186,6 +187,7 @@
                 IsItemClickEnabled="True"
                 ItemClick="ArtistsGridView_ItemClick"
                 Padding="{StaticResource SongListViewPadding}"
+                Margin="{StaticResource SongListViewMargin}"
                 ItemContainerStyle="{StaticResource ArtistPageGridViewItemStyle}"
                 ItemsSource="{x:Bind ViewModel.Artists, Mode=OneWay}"
                 SelectionMode="None"
@@ -259,12 +261,6 @@
                         </Grid>
                     </DataTemplate>
                 </GridView.ItemTemplate>
-                <GridView.Footer>
-                    <uicontrols:PaginationControl
-                        ViewModel="{x:Bind ViewModel}"
-                        HorizontalAlignment="Right"
-                        Margin="0,24,24,16" />
-                </GridView.Footer>
             </GridView>
 
             <!-- Message shown when the library is empty -->

--- a/src/Nagi.WinUI/Pages/ArtistViewPage.xaml
+++ b/src/Nagi.WinUI/Pages/ArtistViewPage.xaml
@@ -341,6 +341,7 @@
                                    Foreground="{ThemeResource TextFillColorSecondary}"
                                    Text="{x:Bind ViewModel.TotalItemsText, Mode=OneWay}"
                                    Visibility="{x:Bind ViewModel.HasSelectedSongs, Mode=OneWay, Converter={StaticResource InverseBooleanToVisibilityConverter}}" />
+                        <uicontrols:PaginationControl ViewModel="{x:Bind ViewModel}" />
                     </StackPanel>
                     <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
                         <!-- Search functionality -->
@@ -420,6 +421,7 @@
             Grid.Row="1"
             x:Name="SongsListView"
             Padding="{StaticResource SongListViewPadding}"
+            Margin="{StaticResource SongListViewMargin}"
             IsItemClickEnabled="True"
             ItemContainerStyle="{StaticResource SongListViewPageListViewItemStyle}"
             ItemsSource="{x:Bind ViewModel.Songs, Mode=OneWay}"
@@ -427,12 +429,6 @@
             SelectionMode="Extended"
             ContainerContentChanging="OnSongsListViewContainerContentChanging"
             DoubleTapped="SongsListView_DoubleTapped">
-            <ListView.Footer>
-                <uicontrols:PaginationControl
-                    ViewModel="{x:Bind ViewModel}"
-                    HorizontalAlignment="Right"
-                    Margin="0,24,24,16" />
-            </ListView.Footer>
             <ListView.ItemTemplate>
                 <DataTemplate x:DataType="models:Song">
                     <Grid Height="54" ColumnSpacing="12" Background="Transparent">

--- a/src/Nagi.WinUI/Pages/FolderPage.xaml
+++ b/src/Nagi.WinUI/Pages/FolderPage.xaml
@@ -56,6 +56,7 @@
             ItemContainerStyle="{StaticResource FolderPageGridViewItemStyle}"
             ItemsSource="{x:Bind ViewModel.Folders, Mode=OneWay}"
             Padding="{StaticResource SongListViewPadding}"
+            Margin="{StaticResource SongListViewMargin}"
             Visibility="{x:Bind ViewModel.HasFolders, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}">
             <GridView.ItemsPanel>
                 <ItemsPanelTemplate>

--- a/src/Nagi.WinUI/Pages/FolderSongViewPage.xaml
+++ b/src/Nagi.WinUI/Pages/FolderSongViewPage.xaml
@@ -312,6 +312,7 @@
                                Foreground="{ThemeResource TextFillColorSecondary}" VerticalAlignment="Center"
                                FontSize="13"
                                Visibility="{x:Bind ViewModel.HasSelectedSongs, Mode=OneWay, Converter={StaticResource InverseBooleanToVisibilityConverter}}" />
+                    <uicontrols:PaginationControl ViewModel="{x:Bind ViewModel}" />
                 </StackPanel>
 
                 <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
@@ -399,6 +400,7 @@
             x:Name="FolderContentsListView"
             Grid.Row="1"
             Padding="{StaticResource SongListViewPadding}"
+            Margin="{StaticResource SongListViewMargin}"
             IsItemClickEnabled="True"
             ItemClick="FolderContentsListView_ItemClick"
             ItemContainerStyle="{StaticResource SongListViewPageListViewItemStyle}"
@@ -408,12 +410,6 @@
             SelectionMode="Extended"
             ContainerContentChanging="OnSongsListViewContainerContentChanging"
             DoubleTapped="FolderContentsListView_DoubleTapped">
-            <ListView.Footer>
-                <uicontrols:PaginationControl
-                    ViewModel="{x:Bind ViewModel}"
-                    HorizontalAlignment="Right"
-                    Margin="0,24,24,16" />
-            </ListView.Footer>
         </ListView>
 
         <!-- Empty State -->

--- a/src/Nagi.WinUI/Pages/GenrePage.xaml
+++ b/src/Nagi.WinUI/Pages/GenrePage.xaml
@@ -169,6 +169,7 @@
                 SelectionMode="None"
                 Visibility="{x:Bind ViewModel.HasGenres, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}"
                 Padding="{StaticResource SongListViewPadding}"
+                Margin="{StaticResource SongListViewMargin}"
                 ItemContainerStyle="{StaticResource GenrePageGridViewItemStyle}">
                 <GridView.ItemsPanel>
                     <ItemsPanelTemplate>

--- a/src/Nagi.WinUI/Pages/GenreViewPage.xaml
+++ b/src/Nagi.WinUI/Pages/GenreViewPage.xaml
@@ -133,6 +133,7 @@
                                    Foreground="{ThemeResource TextFillColorSecondary}"
                                    Text="{x:Bind ViewModel.TotalItemsText, Mode=OneWay}"
                                    Visibility="{x:Bind ViewModel.HasSelectedSongs, Mode=OneWay, Converter={StaticResource InverseBooleanToVisibilityConverter}}" />
+                        <uicontrols:PaginationControl ViewModel="{x:Bind ViewModel}" />
                     </StackPanel>
                     <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
                         <!-- Search functionality -->
@@ -218,6 +219,7 @@
             x:Name="SongsListView"
             Grid.Row="1"
             Padding="{StaticResource SongListViewPadding}"
+            Margin="{StaticResource SongListViewMargin}"
             IsItemClickEnabled="True"
             ItemContainerStyle="{StaticResource SongListViewPageListViewItemStyle}"
             ItemsSource="{x:Bind ViewModel.Songs, Mode=OneWay}"
@@ -225,12 +227,6 @@
             SelectionMode="Extended"
             ContainerContentChanging="OnSongsListViewContainerContentChanging"
             DoubleTapped="SongsListView_DoubleTapped">
-            <ListView.Footer>
-                <uicontrols:PaginationControl
-                    ViewModel="{x:Bind ViewModel}"
-                    HorizontalAlignment="Right"
-                    Margin="0,24,24,16" />
-            </ListView.Footer>
             <ListView.ItemTemplate>
                 <DataTemplate x:DataType="models:Song">
                     <Grid Height="54" ColumnSpacing="12" Background="Transparent">

--- a/src/Nagi.WinUI/Pages/LibraryPage.xaml
+++ b/src/Nagi.WinUI/Pages/LibraryPage.xaml
@@ -121,6 +121,7 @@
                     Foreground="{ThemeResource TextFillColorSecondary}"
                     Text="{x:Bind ViewModel.TotalItemsText, Mode=OneWay}"
                     Visibility="{x:Bind ViewModel.HasSelectedSongs, Mode=OneWay, Converter={StaticResource InverseBooleanToVisibilityConverter}}" />
+                <uicontrols:PaginationControl ViewModel="{x:Bind ViewModel}" />
             </StackPanel>
 
             <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
@@ -209,6 +210,7 @@
             x:Name="SongsListView"
             Grid.Row="1"
             Padding="{StaticResource SongListViewPadding}"
+            Margin="{StaticResource SongListViewMargin}"
             IsItemClickEnabled="True"
             ItemContainerStyle="{StaticResource SongListViewPageListViewItemStyle}"
             ItemsSource="{x:Bind ViewModel.Songs, Mode=OneWay}"
@@ -216,12 +218,6 @@
             SelectionMode="Extended"
             ContainerContentChanging="OnSongsListViewContainerContentChanging"
             DoubleTapped="SongsListView_DoubleTapped">
-            <ListView.Footer>
-                <uicontrols:PaginationControl
-                    ViewModel="{x:Bind ViewModel}"
-                    HorizontalAlignment="Right"
-                    Margin="0,24,24,16" />
-            </ListView.Footer>
             <ListView.ItemTemplate>
                 <DataTemplate x:DataType="models:Song">
                     <Grid Height="54" ColumnSpacing="12" Background="Transparent">

--- a/src/Nagi.WinUI/Pages/PlaylistPage.xaml
+++ b/src/Nagi.WinUI/Pages/PlaylistPage.xaml
@@ -220,6 +220,7 @@
                 IsItemClickEnabled="True"
                 ItemClick="PlaylistsGridView_ItemClick"
                 Padding="{StaticResource SongListViewPadding}"
+                Margin="{StaticResource SongListViewMargin}"
                 ItemContainerStyle="{StaticResource PlaylistPageGridViewItemStyle}"
                 ItemsSource="{x:Bind ViewModel.Playlists, Mode=OneWay}"
                 SelectionMode="None"

--- a/src/Nagi.WinUI/Pages/PlaylistSongViewPage.xaml
+++ b/src/Nagi.WinUI/Pages/PlaylistSongViewPage.xaml
@@ -241,6 +241,7 @@
                   SelectionMode="Extended"
                   IsItemClickEnabled="True"
                   Padding="{StaticResource SongListViewPadding}"
+                  Margin="{StaticResource SongListViewMargin}"
                   ItemsSource="{x:Bind ViewModel.Songs, Mode=OneWay}"
                   ItemContainerStyle="{StaticResource SongListViewPageListViewItemStyle}"
                   CanDragItems="{x:Bind ViewModel.IsReorderingEnabled, Mode=OneWay}"

--- a/src/Nagi.WinUI/Pages/SmartPlaylistSongViewPage.xaml
+++ b/src/Nagi.WinUI/Pages/SmartPlaylistSongViewPage.xaml
@@ -164,6 +164,7 @@
                                Foreground="{ThemeResource TextFillColorSecondary}" VerticalAlignment="Center"
                                FontSize="13"
                                Visibility="{x:Bind ViewModel.HasSelectedSongs, Mode=OneWay, Converter={StaticResource InverseBooleanToVisibilityConverter}}" />
+                    <uicontrols:PaginationControl ViewModel="{x:Bind ViewModel}" />
                 </StackPanel>
 
                 <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
@@ -298,6 +299,7 @@
                   SelectionMode="Extended"
                   IsItemClickEnabled="True"
                   Padding="{StaticResource SongListViewPadding}"
+                  Margin="{StaticResource SongListViewMargin}"
                   ItemsSource="{x:Bind ViewModel.Songs, Mode=OneWay}"
                   ItemContainerStyle="{StaticResource SongListViewPageListViewItemStyle}"
                   SelectionChanged="SongsListView_SelectionChanged"
@@ -306,12 +308,6 @@
                   CanReorderItems="False"
                   AllowDrop="False"
                   DoubleTapped="SongsListView_DoubleTapped">
-            <ListView.Footer>
-                <uicontrols:PaginationControl
-                    ViewModel="{x:Bind ViewModel}"
-                    HorizontalAlignment="Right"
-                    Margin="0,24,24,16" />
-            </ListView.Footer>
             <ListView.ItemTemplate>
                 <DataTemplate x:DataType="models:Song">
                     <Grid Height="54" ColumnSpacing="12" Background="Transparent">

--- a/src/Nagi.WinUI/Styles/Colors.xaml
+++ b/src/Nagi.WinUI/Styles/Colors.xaml
@@ -54,8 +54,9 @@
     <Thickness x:Key="PageHeaderMarginIndented">24,0,24,24</Thickness>
 
     <!-- ListView/GridView Padding -->
-    <Thickness x:Key="SongListViewPadding">24,0,24,132</Thickness>
-    <Thickness x:Key="SongListViewPaddingNoHorizontal">0,0,0,132</Thickness>
+    <Thickness x:Key="SongListViewPadding">24,0,24,0</Thickness>
+    <Thickness x:Key="SongListViewPaddingNoHorizontal">0</Thickness>
+    <Thickness x:Key="SongListViewMargin">0,0,0,132</Thickness>
 
     <!-- Search Box Sizing -->
     <x:Double x:Key="SearchBoxExpandedWidth">300</x:Double>


### PR DESCRIPTION
Moves pagination into list headers and keeps scrollbars above the player.

Closes #130