### PR TITLE
fix: keep large library operations responsive

### DIFF
--- a/src/Nagi.WinUI/MainPage.xaml
+++ b/src/Nagi.WinUI/MainPage.xaml
@@ -608,6 +608,11 @@
                     TextAlignment="Center"
                     TextTrimming="CharacterEllipsis"
                     TextWrapping="NoWrap" />
+                <Button
+                    HorizontalAlignment="Center"
+                    Command="{x:Bind ViewModel.CancelGlobalOperationCommand}"
+                    Content="{x:Bind resources:Strings.Generic_Cancel, Mode=OneTime}"
+                    Visibility="{x:Bind ViewModel.CanCancelGlobalOperation, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}" />
             </StackPanel>
         </Grid>
 

--- a/src/Nagi.WinUI/ViewModels/AlbumViewModel.cs
+++ b/src/Nagi.WinUI/ViewModels/AlbumViewModel.cs
@@ -89,8 +89,8 @@ public partial class AlbumViewModel : PagedListViewModelBase<Album>
     protected override async Task<PagedResult<Album>> LoadPageItemsAsync(int pageNumber, int pageSize, CancellationToken token)
     {
         var pagedResult = IsSearchActive
-            ? await _libraryService.SearchAlbumsPagedAsync(SearchTerm, pageNumber, pageSize)
-            : await _libraryService.GetAllAlbumsPagedAsync(pageNumber, pageSize, CurrentSortOrder);
+            ? await _libraryService.SearchAlbumsPagedAsync(SearchTerm, pageNumber, pageSize, token)
+            : await _libraryService.GetAllAlbumsPagedAsync(pageNumber, pageSize, CurrentSortOrder, token);
 
         token.ThrowIfCancellationRequested();
 

--- a/src/Nagi.WinUI/ViewModels/AlbumViewViewModel.cs
+++ b/src/Nagi.WinUI/ViewModels/AlbumViewViewModel.cs
@@ -77,7 +77,8 @@ public partial class AlbumViewViewModel : SongListViewModelBase
         else
             result = await _libraryReader.GetSongsByAlbumIdPagedAsync(_albumId, pageNumber, pageSize, sortOrder, cancellationToken);
 
-        if (pageNumber == 1) UpdateAlbumDetails(result);
+        if (pageNumber == 1)
+            _dispatcherService.TryEnqueue(() => UpdateAlbumDetails(result));
 
         return result;
     }
@@ -207,7 +208,9 @@ public partial class AlbumViewViewModel : SongListViewModelBase
     {
         try
         {
-            var duration = await _libraryReader.GetSearchTotalDurationInAlbumAsync(_albumId, searchTerm, cancellationToken);
+            var duration = await Task.Run(
+                () => _libraryReader.GetSearchTotalDurationInAlbumAsync(_albumId, searchTerm, cancellationToken),
+                cancellationToken).ConfigureAwait(false);
 
             if (!cancellationToken.IsCancellationRequested)
             {

--- a/src/Nagi.WinUI/ViewModels/ArtistViewModel.cs
+++ b/src/Nagi.WinUI/ViewModels/ArtistViewModel.cs
@@ -93,8 +93,8 @@ public partial class ArtistViewModel : PagedListViewModelBase<Artist>
     protected override async Task<PagedResult<Artist>> LoadPageItemsAsync(int pageNumber, int pageSize, CancellationToken token)
     {
         var pagedResult = IsSearchActive
-            ? await _libraryService.SearchArtistsPagedAsync(SearchTerm, pageNumber, pageSize)
-            : await _libraryService.GetAllArtistsPagedAsync(pageNumber, pageSize, CurrentSortOrder);
+            ? await _libraryService.SearchArtistsPagedAsync(SearchTerm, pageNumber, pageSize, token)
+            : await _libraryService.GetAllArtistsPagedAsync(pageNumber, pageSize, CurrentSortOrder, token);
 
         token.ThrowIfCancellationRequested();
         return pagedResult ?? new PagedResult<Artist>();

--- a/src/Nagi.WinUI/ViewModels/PagedListViewModelBase.cs
+++ b/src/Nagi.WinUI/ViewModels/PagedListViewModelBase.cs
@@ -252,21 +252,26 @@ public abstract partial class PagedListViewModelBase<TItem> : SearchableViewMode
             var pageToLoad = CurrentPage;
             var pageSize = SongsPerPage;
 
-            var auxTask = OnAuxiliaryLoadAsync(token);
-            var pageTask = LoadPageItemsAsync(pageToLoad, pageSize, token);
-            await Task.WhenAll(auxTask, pageTask).ConfigureAwait(false);
-            token.ThrowIfCancellationRequested();
-
-            var pagedResult = pageTask.Result;
-
-            // Past-end clamp: if the requested page exceeds the result set (e.g. items removed),
-            // jump back to the last valid page and refetch.
-            var totalPages = Math.Max(1, pagedResult.TotalPages);
-            if (pageToLoad > totalPages && pagedResult.TotalCount > 0)
+            // SQLite's async APIs still perform native I/O, so keep page loads off the UI thread.
+            var pagedResult = await Task.Run(async () =>
             {
-                pagedResult = await LoadPageItemsAsync(totalPages, pageSize, token).ConfigureAwait(false);
+                var auxTask = OnAuxiliaryLoadAsync(token);
+                var pageTask = LoadPageItemsAsync(pageToLoad, pageSize, token);
+                await Task.WhenAll(auxTask, pageTask).ConfigureAwait(false);
                 token.ThrowIfCancellationRequested();
-            }
+
+                var result = pageTask.Result;
+
+                // Clamp pages past the end after items are removed.
+                var totalPages = Math.Max(1, result.TotalPages);
+                if (pageToLoad > totalPages && result.TotalCount > 0)
+                {
+                    result = await LoadPageItemsAsync(totalPages, pageSize, token).ConfigureAwait(false);
+                    token.ThrowIfCancellationRequested();
+                }
+
+                return result;
+            }, token);
 
             ProcessPagedResult(pagedResult, token);
 

--- a/src/Nagi.WinUI/ViewModels/PlayerViewModel.cs
+++ b/src/Nagi.WinUI/ViewModels/PlayerViewModel.cs
@@ -59,6 +59,7 @@ public partial class PlayerViewModel : ObservableObject
 
     // Queue display update cancellation
     private CancellationTokenSource? _queueDisplayCts;
+    private Action? _cancelGlobalOperation;
 
     // Navigation re-entry guards
     private bool _isNavigatingToArtist;
@@ -138,6 +139,9 @@ public partial class PlayerViewModel : ObservableObject
     [ObservableProperty] public partial string GlobalOperationStatusMessage { get; set; }
     [ObservableProperty] public partial double GlobalOperationProgressValue { get; set; }
     [ObservableProperty] public partial bool IsGlobalOperationIndeterminate { get; set; }
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(CancelGlobalOperationCommand))]
+    public partial bool CanCancelGlobalOperation { get; set; }
     [ObservableProperty] public partial bool IsQueueViewVisible { get; set; }
 
     [ObservableProperty] public partial bool IsVolumeControlVisible { get; set; }
@@ -167,6 +171,28 @@ public partial class PlayerViewModel : ObservableObject
     };
 
     public string VolumeButtonToolTip => IsMuted ? Strings.Tooltip_Unmute : Strings.Tooltip_Mute;
+
+    public void SetGlobalOperationCancellation(Action? cancel)
+    {
+        Interlocked.Exchange(ref _cancelGlobalOperation, cancel);
+        CanCancelGlobalOperation = cancel is not null;
+    }
+
+    [RelayCommand(CanExecute = nameof(CanCancelGlobalOperation))]
+    private void CancelGlobalOperation()
+    {
+        var cancel = Interlocked.Exchange(ref _cancelGlobalOperation, null);
+        CanCancelGlobalOperation = false;
+
+        try
+        {
+            cancel?.Invoke();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to cancel the active global operation");
+        }
+    }
 
     partial void OnIsPlayingChanged(bool value)
     {
@@ -208,6 +234,8 @@ public partial class PlayerViewModel : ObservableObject
         _queueDisplayCts?.Cancel();
         _queueDisplayCts?.Dispose();
         _queueDisplayCts = null;
+        Interlocked.Exchange(ref _cancelGlobalOperation, null);
+        CanCancelGlobalOperation = false;
     }
 
 

--- a/src/Nagi.WinUI/ViewModels/SettingsViewModel.cs
+++ b/src/Nagi.WinUI/ViewModels/SettingsViewModel.cs
@@ -128,6 +128,7 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
     private bool _isInitializing;
     private bool _isLoaded;
     private CancellationTokenSource? _preampDebounceCts;
+    private CancellationTokenSource? _metadataRescanCts;
     private CancellationTokenSource? _replayGainScanCts;
     private CancellationTokenSource? _playerButtonSaveCts;
     private CancellationTokenSource? _navigationItemSaveCts;
@@ -429,8 +430,11 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
         }
         _preampDebounceCts?.Cancel();
         _preampDebounceCts?.Dispose();
+        _metadataRescanCts?.Cancel();
+        _metadataRescanCts?.Dispose();
         _replayGainScanCts?.Cancel();
         _replayGainScanCts?.Dispose();
+        _playerViewModel.SetGlobalOperationCancellation(null);
         _playerButtonSaveCts?.Cancel();
         _playerButtonSaveCts?.Dispose();
         _navigationItemSaveCts?.Cancel();
@@ -1304,22 +1308,33 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
 
         if (!confirmed) return;
 
+        _metadataRescanCts?.Cancel();
+        _metadataRescanCts?.Dispose();
+        _metadataRescanCts = new CancellationTokenSource();
+        var scanCts = _metadataRescanCts;
+
         _playerViewModel.IsGlobalOperationInProgress = true;
         _playerViewModel.GlobalOperationStatusMessage = Nagi.WinUI.Resources.Strings.Settings_Status_Rescan_Preparing;
         _playerViewModel.IsGlobalOperationIndeterminate = true;
+        _playerViewModel.SetGlobalOperationCancellation(scanCts.Cancel);
 
         try
         {
             var progress = new Progress<ScanProgress>(p =>
             {
                 _playerViewModel.GlobalOperationStatusMessage = p.StatusText;
-                _playerViewModel.IsGlobalOperationIndeterminate = p.IsIndeterminate || p.Percentage < 5;
+                _playerViewModel.IsGlobalOperationIndeterminate = p.IsIndeterminate;
                 _playerViewModel.GlobalOperationProgressValue = p.Percentage;
             });
 
-            await _libraryScanner.ForceRescanMetadataAsync(progress);
+            await _libraryScanner.ForceRescanMetadataAsync(progress, scanCts.Token);
+            if (scanCts.IsCancellationRequested) return;
 
             await _uiService.ShowMessageDialogAsync(Nagi.WinUI.Resources.Strings.Settings_Dialog_RescanComplete_Title, Nagi.WinUI.Resources.Strings.Settings_Dialog_RescanComplete_Content);
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogDebug("Metadata rescan was cancelled.");
         }
         catch (Exception ex)
         {
@@ -1328,8 +1343,12 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
         }
         finally
         {
+            _playerViewModel.SetGlobalOperationCancellation(null);
             _playerViewModel.IsGlobalOperationInProgress = false;
             _playerViewModel.IsGlobalOperationIndeterminate = false;
+            if (ReferenceEquals(_metadataRescanCts, scanCts))
+                _metadataRescanCts = null;
+            scanCts.Dispose();
         }
     }
 
@@ -1793,11 +1812,13 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
         _replayGainScanCts?.Cancel();
         _replayGainScanCts?.Dispose();
         _replayGainScanCts = new CancellationTokenSource();
-        var cancellationToken = _replayGainScanCts.Token;
+        var scanCts = _replayGainScanCts;
+        var cancellationToken = scanCts.Token;
 
         _playerViewModel.IsGlobalOperationInProgress = true;
         _playerViewModel.GlobalOperationStatusMessage = Nagi.WinUI.Resources.Strings.Settings_Status_VolumeNorm_Preparing;
         _playerViewModel.IsGlobalOperationIndeterminate = true;
+        _playerViewModel.SetGlobalOperationCancellation(scanCts.Cancel);
 
         try
         {
@@ -1821,6 +1842,7 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
         }
         finally
         {
+            _playerViewModel.SetGlobalOperationCancellation(null);
             _playerViewModel.IsGlobalOperationInProgress = false;
             _playerViewModel.IsGlobalOperationIndeterminate = false;
         }

--- a/src/Nagi.WinUI/ViewModels/SongListViewModelBase.cs
+++ b/src/Nagi.WinUI/ViewModels/SongListViewModelBase.cs
@@ -19,10 +19,7 @@ using Nagi.WinUI.Helpers;
 namespace Nagi.WinUI.ViewModels;
 
 /// <summary>
-///     Base class for song list view models. Adds selection, playback commands, the
-///     full ID list (used for "Play All" without holding every <see cref="Song"/> in
-///     memory), and infinite-scroll auto-loading when
-///     <see cref="PagedListViewModelBase{TItem}.IsPaginationEnabled"/> is false.
+///     Adds selection, playback, and infinite scrolling to song lists.
 /// </summary>
 public abstract partial class SongListViewModelBase : PagedListViewModelBase<Song>
 {
@@ -44,7 +41,7 @@ public abstract partial class SongListViewModelBase : PagedListViewModelBase<Son
     /// </summary>
     [ObservableProperty] public partial Guid? CurrentPlayingSongId { get; set; }
 
-    // For paged views, this holds all song IDs to enable "Play All" without loading all song objects into memory.
+    // Search results load this list on demand.
     protected List<Guid> _fullSongIdList = new();
 
     // Owned by the song-base's <see cref="LoadPageAsync"/> envelope (Next/Previous reload that skips
@@ -160,7 +157,7 @@ public abstract partial class SongListViewModelBase : PagedListViewModelBase<Son
             _stateLock.EnterReadLock();
             try
             {
-                return SelectionState.GetSelectedCount(_fullSongIdList.Count);
+                return SelectionState.GetSelectedCount(TotalItemCount);
             }
             finally
             {
@@ -209,6 +206,7 @@ public abstract partial class SongListViewModelBase : PagedListViewModelBase<Son
     protected override void OnSearchTermChangedInternal(string value)
     {
         if (HasSelectedSongs) DeselectAll();
+        ClearFullSongIds();
     }
 
     protected override async Task ExecuteSearchAsync(CancellationToken token)
@@ -226,14 +224,42 @@ public abstract partial class SongListViewModelBase : PagedListViewModelBase<Son
         return LoadSongsPagedAsync(pageNumber, pageSize, CurrentSortOrder, token);
     }
 
-    /// <summary>Run the full ID fetch (used by Play All) in parallel with the page query.</summary>
+    /// <summary>Refreshes the playback ID cache for non-search loads.</summary>
     protected override async Task OnAuxiliaryLoadAsync(CancellationToken token)
     {
+        if (IsSearchActive)
+        {
+            ClearFullSongIds();
+            return;
+        }
+
         var ids = await LoadAllSongIdsAsync(CurrentSortOrder, token).ConfigureAwait(false);
         token.ThrowIfCancellationRequested();
+
         _stateLock.EnterWriteLock();
         try { _fullSongIdList = ids; }
         finally { _stateLock.ExitWriteLock(); }
+    }
+
+    private void ClearFullSongIds()
+    {
+        _stateLock.EnterWriteLock();
+        try { _fullSongIdList = new List<Guid>(); }
+        finally { _stateLock.ExitWriteLock(); }
+    }
+
+    private async Task<List<Guid>> GetFullSongIdsAsync()
+    {
+        _stateLock.EnterReadLock();
+        try
+        {
+            if (_fullSongIdList.Count > 0) return _fullSongIdList.ToList();
+        }
+        finally { _stateLock.ExitReadLock(); }
+
+        var sortOrder = CurrentSortOrder;
+        return await Task.Run(() => LoadAllSongIdsAsync(sortOrder, CancellationToken.None))
+            .ConfigureAwait(false);
     }
 
     /// <summary>
@@ -299,7 +325,8 @@ public abstract partial class SongListViewModelBase : PagedListViewModelBase<Son
                 await Task.Delay(100, token);
                 if (token.IsCancellationRequested) break;
 
-                var pagedResult = await LoadSongsPagedAsync(nextPageToLoad, SongsPerPage, CurrentSortOrder, token);
+                var pagedResult = await Task.Run(
+                    () => LoadSongsPagedAsync(nextPageToLoad, SongsPerPage, CurrentSortOrder, token), token);
                 if (pagedResult == null) break;
 
                 ProcessPagedResult(pagedResult, token, true);
@@ -338,7 +365,8 @@ public abstract partial class SongListViewModelBase : PagedListViewModelBase<Son
             _pagedLoadCts = new CancellationTokenSource();
             var token = _pagedLoadCts.Token;
 
-            var pagedResult = await LoadSongsPagedAsync(pageNumber, SongsPerPage, CurrentSortOrder, token);
+            var pagedResult = await Task.Run(
+                () => LoadSongsPagedAsync(pageNumber, SongsPerPage, CurrentSortOrder, token), token);
             ProcessPagedResult(pagedResult, token);
         }
         catch (Exception ex)
@@ -426,34 +454,16 @@ public abstract partial class SongListViewModelBase : PagedListViewModelBase<Son
     [RelayCommand(CanExecute = nameof(CanExecutePlayAllCommands))]
     private async Task PlayAllSongsAsync()
     {
-        // Always use the pre-fetched full ID list for memory efficiency and consistency.
-        List<Guid> ids;
-        _stateLock.EnterReadLock();
-        try
-        {
-            ids = _fullSongIdList.ToList();
-        }
-        finally
-        {
-            _stateLock.ExitReadLock();
-        }
+        var ids = await GetFullSongIdsAsync();
+        if (ids.Count == 0) return;
         await _playbackService.PlayAsync(ids, 0, null, GetPlaybackContext());
     }
 
     [RelayCommand(CanExecute = nameof(CanExecutePlayAllCommands))]
     private async Task ShuffleAndPlayAllSongsAsync()
     {
-        // Always use the pre-fetched full ID list for memory efficiency and consistency.
-        List<Guid> ids;
-        _stateLock.EnterReadLock();
-        try
-        {
-            ids = _fullSongIdList.ToList();
-        }
-        finally
-        {
-            _stateLock.ExitReadLock();
-        }
+        var ids = await GetFullSongIdsAsync();
+        if (ids.Count == 0) return;
         await _playbackService.PlayAsync(ids, 0, true, GetPlaybackContext());
     }
 
@@ -462,19 +472,8 @@ public abstract partial class SongListViewModelBase : PagedListViewModelBase<Son
     {
         if (song == null) return;
 
-        // Always use the pre-fetched full ID list to find the song's position.
-        int startIndex;
-        List<Guid> ids;
-        _stateLock.EnterReadLock();
-        try
-        {
-            startIndex = _fullSongIdList.IndexOf(song.Id);
-            ids = _fullSongIdList.ToList();
-        }
-        finally
-        {
-            _stateLock.ExitReadLock();
-        }
+        var ids = await GetFullSongIdsAsync();
+        var startIndex = ids.IndexOf(song.Id);
 
         if (startIndex == -1)
         {
@@ -579,16 +578,7 @@ public abstract partial class SongListViewModelBase : PagedListViewModelBase<Son
 
     private bool CanExecutePlayAllCommands()
     {
-        // Always use the pre-fetched full ID list for consistency.
-        _stateLock.EnterReadLock();
-        try
-        {
-            return !IsLoading && _fullSongIdList.Any();
-        }
-        finally
-        {
-            _stateLock.ExitReadLock();
-        }
+        return !IsLoading && Songs.Any();
     }
 
     private bool CanExecuteSelectedSongsCommands()
@@ -618,12 +608,13 @@ public abstract partial class SongListViewModelBase : PagedListViewModelBase<Son
         UpdateSelectionDependentCommands();
     }
 
-    protected virtual Task<List<Guid>> GetCurrentSelectionIdsAsync()
+    protected virtual async Task<List<Guid>> GetCurrentSelectionIdsAsync()
     {
+        var ids = await GetFullSongIdsAsync();
         _stateLock.EnterReadLock();
         try
         {
-            return Task.FromResult(SelectionState.GetSelectedIds(_fullSongIdList).ToList());
+            return SelectionState.GetSelectedIds(ids).ToList();
         }
         finally
         {
@@ -743,6 +734,7 @@ public abstract partial class SongListViewModelBase : PagedListViewModelBase<Son
     {
         base.ResetState();
         SelectionState.DeselectAll();
+        ClearFullSongIds();
         CancelInflightPageLoad();
         _pagedLoadCts?.Cancel();
         _pagedLoadCts?.Dispose();


### PR DESCRIPTION
Moves database-backed page loads off the UI thread, defers full search ID loading, and makes metadata rescans cancellable.

Closes #133