### PR TITLE
fix: update LibVLC for audio device changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,7 @@ jobs:
           cache-dependency-path: |
             **/*.csproj
             **/Directory.Build.props
+            **/Directory.Packages.props
             **/NuGet.config
 
       - uses: FedericoCarboni/setup-ffmpeg@v3.1
@@ -57,6 +58,7 @@ jobs:
           cache-dependency-path: |
             **/*.csproj
             **/Directory.Build.props
+            **/Directory.Packages.props
             **/NuGet.config
 
       - run: dotnet publish api/NagiAppFunctions/NagiAppFunctions.csproj -c Release -o ./functions-output
@@ -101,6 +103,7 @@ jobs:
           cache-dependency-path: |
             **/*.csproj
             **/Directory.Build.props
+            **/Directory.Packages.props
             **/NuGet.config
 
       - uses: FedericoCarboni/setup-ffmpeg@v3.1
@@ -176,6 +179,7 @@ jobs:
           cache-dependency-path: |
             **/*.csproj
             **/Directory.Build.props
+            **/Directory.Packages.props
             **/NuGet.config
 
       - name: Get version

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,8 +32,8 @@
     <PackageVersion Include="Polly" Version="8.7.0" />
     <PackageVersion Include="Polly.RateLimiting" Version="8.7.0" />
     <!-- Media Playback -->
-    <PackageVersion Include="LibVLCSharp" Version="4.0.0-alpha-20260709-10120" />
-    <PackageVersion Include="VideoLAN.LibVLC.Windows" Version="4.0.0-alpha-20260709" />
+    <PackageVersion Include="LibVLCSharp" Version="4.0.0-alpha-20260828-10280" />
+    <PackageVersion Include="VideoLAN.LibVLC.Windows" Version="4.0.0-alpha-20260829" />
     <!-- Serilog -->
     <PackageVersion Include="Serilog.Enrichers.Thread" Version="4.0.0" />
     <PackageVersion Include="Serilog.Extensions.Logging" Version="10.0.0" />

--- a/src/Nagi.WinUI/Services/Implementations/LibVlcAudioPlayerService.cs
+++ b/src/Nagi.WinUI/Services/Implementations/LibVlcAudioPlayerService.cs
@@ -263,7 +263,7 @@ public sealed class LibVlcAudioPlayerService : IAudioPlayer, IDisposable
     public event Action<string>? ErrorOccurred;
     public event Action? SmtcNextButtonPressed, SmtcPreviousButtonPressed;
 
-    public bool IsPlaying => !_isDisposed && _isInitialized && !_isPausing && (_mediaPlayer?.IsPlaying ?? false);
+    public bool IsPlaying => !_isDisposed && _isInitialized && !_isPausing && _mediaPlayer?.State == VLCState.Playing;
     public TimeSpan CurrentPosition => _isDisposed || !_isInitialized
         ? TimeSpan.Zero
         : FromVlcMicroseconds(_mediaPlayer?.Time ?? 0);


### PR DESCRIPTION
Updates VLC nightlies for the upstream device-change fix and includes central package versions in the CI NuGet cache key.

Upstream: https://code.videolan.org/videolan/vlc/-/merge_requests/9726
Closes #129