### PR TITLE
fix: restore the window on tray double-click

### DIFF
--- a/src/Nagi.WinUI/Controls/TrayIconUserControl.xaml
+++ b/src/Nagi.WinUI/Controls/TrayIconUserControl.xaml
@@ -19,6 +19,7 @@
         LeftClickCommand="{x:Bind ViewModel.ShowPopupCommand}"
         LeftClickCommandParameter="{Binding RelativeSource={RelativeSource Self}}"
         NoLeftClickDelay="True"
+        DoubleClickCommand="{x:Bind ViewModel.RestoreWindowCommand}"
         ToolTipText="{x:Bind ViewModel.ToolTipText, Mode=OneWay}"
         ContextMenuMode="SecondWindow">
 

--- a/src/Nagi.WinUI/Services/Implementations/TrayPopupService.cs
+++ b/src/Nagi.WinUI/Services/Implementations/TrayPopupService.cs
@@ -87,13 +87,21 @@ public class TrayPopupService : ITrayPopupService, IDisposable
 
     public async Task HidePopup()
     {
-        if (_popupWindow != null && _popupWindow.AppWindow.IsVisible && !_isAnimating)
+        if (_popupWindow == null || !_popupWindow.AppWindow.IsVisible) return;
+
+        _logger.LogDebug("Hiding tray popup.");
+        if (_isAnimating)
         {
-            _logger.LogDebug("Hiding tray popup.");
-            _isAnimating = true;
-            await PopupAnimation.AnimateOut(_popupWindow);
+            PopupAnimation.CancelAllAnimations();
+            _popupWindow.AppWindow.Hide();
+            _popupWindow.SetWindowOpacity(255);
             _isAnimating = false;
+            return;
         }
+
+        _isAnimating = true;
+        await PopupAnimation.AnimateOut(_popupWindow);
+        _isAnimating = false;
     }
 
     private async Task ShowPopup(RectInt32? targetRect = null)

--- a/src/Nagi.WinUI/ViewModels/TrayIconViewModel.cs
+++ b/src/Nagi.WinUI/ViewModels/TrayIconViewModel.cs
@@ -169,6 +169,12 @@ public partial class TrayIconViewModel : ObservableObject
     [RelayCommand]
     private void ShowPopup(object? parameter)
     {
+        if (_windowService.IsVisible)
+        {
+            _trayPopupService.HidePopup();
+            return;
+        }
+
         RectInt32? iconRect = null;
         if (parameter != null)
         {


### PR DESCRIPTION
Keeps single-click flyout behavior and restores the full window on double-click.

Closes #132