### PR TITLE
fix: keep library navigation above the player

### DIFF
--- a/src/Nagi.WinUI/Pages/AlbumPage.xaml
+++ b/src/Nagi.WinUI/Pages/AlbumPage.xaml
@@ -18,7 +18,8 @@
 
 
 
-    <Grid Padding="{StaticResource PageContainerPaddingVertical}">
+    <Grid Padding="{StaticResource PageContainerPaddingVertical}"
+          Margin="{StaticResource SongListViewMargin}">
         <VisualStateManager.VisualStateGroups>
             <VisualStateGroup x:Name="SearchStates">
                 <VisualState x:Name="SearchCollapsed">
@@ -104,6 +105,7 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
         <!-- Page Header -->
@@ -277,12 +279,6 @@
                         </Grid>
                     </DataTemplate>
                 </GridView.ItemTemplate>
-                <GridView.Footer>
-                    <uicontrols:PaginationControl
-                        ViewModel="{x:Bind ViewModel}"
-                        HorizontalAlignment="Right"
-                        Margin="0,24,24,16" />
-                </GridView.Footer>
             </GridView>
 
             <!-- Message shown when the library is empty -->
@@ -313,5 +309,11 @@
                     Foreground="{ThemeResource TextFillColorTertiaryBrush}" />
             </StackPanel>
         </Grid>
+
+        <uicontrols:PaginationControl
+            Grid.Row="2"
+            ViewModel="{x:Bind ViewModel}"
+            HorizontalAlignment="Right"
+            Margin="0,16,24,16" />
     </Grid>
 </Page>

--- a/src/Nagi.WinUI/Pages/AlbumViewPage.xaml
+++ b/src/Nagi.WinUI/Pages/AlbumViewPage.xaml
@@ -22,7 +22,9 @@
         </ResourceDictionary>
     </Page.Resources>
 
-    <Grid KeyboardAcceleratorPlacementMode="Hidden" Padding="0,0,0,24">
+    <Grid KeyboardAcceleratorPlacementMode="Hidden"
+          Padding="0,0,0,24"
+          Margin="{StaticResource SongListViewMargin}">
         <Grid.KeyboardAccelerators>
             <KeyboardAccelerator Key="A" Modifiers="Control" Invoked="OnSelectAllAcceleratorInvoked" />
         </Grid.KeyboardAccelerators>
@@ -98,6 +100,7 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
         <StackPanel Grid.Row="0" Padding="{StaticResource ViewPageHeaderPadding}" Spacing="16">
@@ -242,12 +245,6 @@
             ContainerContentChanging="OnSongsListViewContainerContentChanging"
             DoubleTapped="GroupedSongsListView_DoubleTapped"
             Visibility="{x:Bind ViewModel.IsGroupedByDisc, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
-            <ListView.Footer>
-                <uicontrols:PaginationControl
-                    ViewModel="{x:Bind ViewModel}"
-                    HorizontalAlignment="Right"
-                    Margin="0,24,24,16" />
-            </ListView.Footer>
             <ListView.ItemContainerStyleSelector>
                 <local:DiscGroupStyleSelector>
                     <local:DiscGroupStyleSelector.HeaderStyle>
@@ -326,12 +323,6 @@
             ContainerContentChanging="OnSongsListViewContainerContentChanging"
             DoubleTapped="SongsListView_DoubleTapped"
             Visibility="{x:Bind ViewModel.IsGroupedByDisc, Mode=OneWay, Converter={StaticResource InverseBooleanToVisibilityConverter}}">
-            <ListView.Footer>
-                <uicontrols:PaginationControl
-                    ViewModel="{x:Bind ViewModel}"
-                    HorizontalAlignment="Right"
-                    Margin="0,24,24,16" />
-            </ListView.Footer>
             <ListView.ItemTemplate>
                 <DataTemplate x:DataType="models:Song">
                     <Grid Height="54" ColumnSpacing="12" Background="Transparent">
@@ -409,6 +400,12 @@
                 </DataTemplate>
             </ListView.ItemTemplate>
         </ListView>
+
+        <uicontrols:PaginationControl
+            Grid.Row="2"
+            ViewModel="{x:Bind ViewModel}"
+            HorizontalAlignment="Right"
+            Margin="0,16,24,16" />
 
         <!-- Empty State -->
         <StackPanel

--- a/src/Nagi.WinUI/Pages/ArtistPage.xaml
+++ b/src/Nagi.WinUI/Pages/ArtistPage.xaml
@@ -17,7 +17,8 @@
 
 
 
-    <Grid Padding="{StaticResource PageContainerPaddingVertical}">
+    <Grid Padding="{StaticResource PageContainerPaddingVertical}"
+          Margin="{StaticResource SongListViewMargin}">
         <VisualStateManager.VisualStateGroups>
             <VisualStateGroup x:Name="SearchStates">
                 <VisualState x:Name="SearchCollapsed">
@@ -103,6 +104,7 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
         <!-- Page Header -->
@@ -259,12 +261,6 @@
                         </Grid>
                     </DataTemplate>
                 </GridView.ItemTemplate>
-                <GridView.Footer>
-                    <uicontrols:PaginationControl
-                        ViewModel="{x:Bind ViewModel}"
-                        HorizontalAlignment="Right"
-                        Margin="0,24,24,16" />
-                </GridView.Footer>
             </GridView>
 
             <!-- Message shown when the library is empty -->
@@ -295,5 +291,11 @@
                     Foreground="{ThemeResource TextFillColorTertiaryBrush}" />
             </StackPanel>
         </Grid>
+
+        <uicontrols:PaginationControl
+            Grid.Row="2"
+            ViewModel="{x:Bind ViewModel}"
+            HorizontalAlignment="Right"
+            Margin="0,16,24,16" />
     </Grid>
 </Page>

--- a/src/Nagi.WinUI/Pages/ArtistViewPage.xaml
+++ b/src/Nagi.WinUI/Pages/ArtistViewPage.xaml
@@ -130,7 +130,9 @@
         </DataTemplate>
     </Page.Resources>
 
-    <Grid KeyboardAcceleratorPlacementMode="Hidden" Padding="0,0,0,24">
+    <Grid KeyboardAcceleratorPlacementMode="Hidden"
+          Padding="0,0,0,24"
+          Margin="{StaticResource SongListViewMargin}">
         <Grid.KeyboardAccelerators>
             <KeyboardAccelerator Key="A" Modifiers="Control" Invoked="OnSelectAllAcceleratorInvoked" />
         </Grid.KeyboardAccelerators>
@@ -228,6 +230,7 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
         <ScrollViewer Grid.Row="0" VerticalScrollBarVisibility="Auto">
@@ -427,12 +430,6 @@
             SelectionMode="Extended"
             ContainerContentChanging="OnSongsListViewContainerContentChanging"
             DoubleTapped="SongsListView_DoubleTapped">
-            <ListView.Footer>
-                <uicontrols:PaginationControl
-                    ViewModel="{x:Bind ViewModel}"
-                    HorizontalAlignment="Right"
-                    Margin="0,24,24,16" />
-            </ListView.Footer>
             <ListView.ItemTemplate>
                 <DataTemplate x:DataType="models:Song">
                     <Grid Height="54" ColumnSpacing="12" Background="Transparent">
@@ -519,6 +516,12 @@
                 </DataTemplate>
             </ListView.ItemTemplate>
         </ListView>
+
+        <uicontrols:PaginationControl
+            Grid.Row="2"
+            ViewModel="{x:Bind ViewModel}"
+            HorizontalAlignment="Right"
+            Margin="0,16,24,16" />
 
         <!-- Empty State -->
         <StackPanel

--- a/src/Nagi.WinUI/Pages/FolderPage.xaml
+++ b/src/Nagi.WinUI/Pages/FolderPage.xaml
@@ -56,6 +56,7 @@
             ItemContainerStyle="{StaticResource FolderPageGridViewItemStyle}"
             ItemsSource="{x:Bind ViewModel.Folders, Mode=OneWay}"
             Padding="{StaticResource SongListViewPadding}"
+            Margin="{StaticResource SongListViewMargin}"
             Visibility="{x:Bind ViewModel.HasFolders, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}">
             <GridView.ItemsPanel>
                 <ItemsPanelTemplate>

--- a/src/Nagi.WinUI/Pages/FolderSongViewPage.xaml
+++ b/src/Nagi.WinUI/Pages/FolderSongViewPage.xaml
@@ -154,7 +154,9 @@
         </local:FolderContentItemTemplateSelector>
     </Page.Resources>
 
-    <Grid KeyboardAcceleratorPlacementMode="Hidden" Padding="0,0,0,24">
+    <Grid KeyboardAcceleratorPlacementMode="Hidden"
+          Padding="0,0,0,24"
+          Margin="{StaticResource SongListViewMargin}">
         <Grid.KeyboardAccelerators>
             <KeyboardAccelerator Key="A" Modifiers="Control" Invoked="OnSelectAllAcceleratorInvoked" />
         </Grid.KeyboardAccelerators>
@@ -230,6 +232,7 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
         <!-- Header Content -->
@@ -408,13 +411,13 @@
             SelectionMode="Extended"
             ContainerContentChanging="OnSongsListViewContainerContentChanging"
             DoubleTapped="FolderContentsListView_DoubleTapped">
-            <ListView.Footer>
-                <uicontrols:PaginationControl
-                    ViewModel="{x:Bind ViewModel}"
-                    HorizontalAlignment="Right"
-                    Margin="0,24,24,16" />
-            </ListView.Footer>
         </ListView>
+
+        <uicontrols:PaginationControl
+            Grid.Row="2"
+            ViewModel="{x:Bind ViewModel}"
+            HorizontalAlignment="Right"
+            Margin="0,16,24,16" />
 
         <!-- Empty State -->
         <StackPanel

--- a/src/Nagi.WinUI/Pages/GenrePage.xaml
+++ b/src/Nagi.WinUI/Pages/GenrePage.xaml
@@ -169,6 +169,7 @@
                 SelectionMode="None"
                 Visibility="{x:Bind ViewModel.HasGenres, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}"
                 Padding="{StaticResource SongListViewPadding}"
+                Margin="{StaticResource SongListViewMargin}"
                 ItemContainerStyle="{StaticResource GenrePageGridViewItemStyle}">
                 <GridView.ItemsPanel>
                     <ItemsPanelTemplate>

--- a/src/Nagi.WinUI/Pages/GenreViewPage.xaml
+++ b/src/Nagi.WinUI/Pages/GenreViewPage.xaml
@@ -17,7 +17,9 @@
 
 
 
-    <Grid KeyboardAcceleratorPlacementMode="Hidden" Padding="0,0,0,24">
+    <Grid KeyboardAcceleratorPlacementMode="Hidden"
+          Padding="0,0,0,24"
+          Margin="{StaticResource SongListViewMargin}">
         <Grid.KeyboardAccelerators>
             <KeyboardAccelerator Key="A" Modifiers="Control" Invoked="OnSelectAllAcceleratorInvoked" />
         </Grid.KeyboardAccelerators>
@@ -93,6 +95,7 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
         <StackPanel Grid.Row="0" Padding="{StaticResource ViewPageHeaderPadding}" Spacing="16">
@@ -225,12 +228,6 @@
             SelectionMode="Extended"
             ContainerContentChanging="OnSongsListViewContainerContentChanging"
             DoubleTapped="SongsListView_DoubleTapped">
-            <ListView.Footer>
-                <uicontrols:PaginationControl
-                    ViewModel="{x:Bind ViewModel}"
-                    HorizontalAlignment="Right"
-                    Margin="0,24,24,16" />
-            </ListView.Footer>
             <ListView.ItemTemplate>
                 <DataTemplate x:DataType="models:Song">
                     <Grid Height="54" ColumnSpacing="12" Background="Transparent">
@@ -312,6 +309,12 @@
                 </DataTemplate>
             </ListView.ItemTemplate>
         </ListView>
+
+        <uicontrols:PaginationControl
+            Grid.Row="2"
+            ViewModel="{x:Bind ViewModel}"
+            HorizontalAlignment="Right"
+            Margin="0,16,24,16" />
 
         <!-- Empty State -->
         <StackPanel

--- a/src/Nagi.WinUI/Pages/LibraryPage.xaml
+++ b/src/Nagi.WinUI/Pages/LibraryPage.xaml
@@ -19,7 +19,9 @@
     <Page.Resources>
     </Page.Resources>
 
-    <Grid KeyboardAcceleratorPlacementMode="Hidden" Padding="{StaticResource PageContainerPaddingVertical}">
+    <Grid KeyboardAcceleratorPlacementMode="Hidden"
+          Padding="{StaticResource PageContainerPaddingVertical}"
+          Margin="{StaticResource SongListViewMargin}">
         <Grid.KeyboardAccelerators>
             <KeyboardAccelerator Key="A" Modifiers="Control" Invoked="OnSelectAllAcceleratorInvoked" />
         </Grid.KeyboardAccelerators>
@@ -95,6 +97,7 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
         <Grid Grid.Row="0"
@@ -216,12 +219,6 @@
             SelectionMode="Extended"
             ContainerContentChanging="OnSongsListViewContainerContentChanging"
             DoubleTapped="SongsListView_DoubleTapped">
-            <ListView.Footer>
-                <uicontrols:PaginationControl
-                    ViewModel="{x:Bind ViewModel}"
-                    HorizontalAlignment="Right"
-                    Margin="0,24,24,16" />
-            </ListView.Footer>
             <ListView.ItemTemplate>
                 <DataTemplate x:DataType="models:Song">
                     <Grid Height="54" ColumnSpacing="12" Background="Transparent">
@@ -319,6 +316,12 @@
                 </DataTemplate>
             </ListView.ItemTemplate>
         </ListView>
+
+        <uicontrols:PaginationControl
+            Grid.Row="2"
+            ViewModel="{x:Bind ViewModel}"
+            HorizontalAlignment="Right"
+            Margin="0,16,24,16" />
 
         <!-- Empty State -->
         <StackPanel

--- a/src/Nagi.WinUI/Pages/PlaylistPage.xaml
+++ b/src/Nagi.WinUI/Pages/PlaylistPage.xaml
@@ -220,6 +220,7 @@
                 IsItemClickEnabled="True"
                 ItemClick="PlaylistsGridView_ItemClick"
                 Padding="{StaticResource SongListViewPadding}"
+                Margin="{StaticResource SongListViewMargin}"
                 ItemContainerStyle="{StaticResource PlaylistPageGridViewItemStyle}"
                 ItemsSource="{x:Bind ViewModel.Playlists, Mode=OneWay}"
                 SelectionMode="None"

--- a/src/Nagi.WinUI/Pages/PlaylistSongViewPage.xaml
+++ b/src/Nagi.WinUI/Pages/PlaylistSongViewPage.xaml
@@ -241,6 +241,7 @@
                   SelectionMode="Extended"
                   IsItemClickEnabled="True"
                   Padding="{StaticResource SongListViewPadding}"
+                  Margin="{StaticResource SongListViewMargin}"
                   ItemsSource="{x:Bind ViewModel.Songs, Mode=OneWay}"
                   ItemContainerStyle="{StaticResource SongListViewPageListViewItemStyle}"
                   CanDragItems="{x:Bind ViewModel.IsReorderingEnabled, Mode=OneWay}"

--- a/src/Nagi.WinUI/Pages/SmartPlaylistSongViewPage.xaml
+++ b/src/Nagi.WinUI/Pages/SmartPlaylistSongViewPage.xaml
@@ -19,7 +19,9 @@
 
     </Page.Resources>
 
-    <Grid KeyboardAcceleratorPlacementMode="Hidden" Padding="0,0,0,24">
+    <Grid KeyboardAcceleratorPlacementMode="Hidden"
+          Padding="0,0,0,24"
+          Margin="{StaticResource SongListViewMargin}">
         <Grid.KeyboardAccelerators>
             <KeyboardAccelerator Key="A" Modifiers="Control" Invoked="OnSelectAllAcceleratorInvoked" />
         </Grid.KeyboardAccelerators>
@@ -95,6 +97,7 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
         <!-- Header Content -->
@@ -306,12 +309,6 @@
                   CanReorderItems="False"
                   AllowDrop="False"
                   DoubleTapped="SongsListView_DoubleTapped">
-            <ListView.Footer>
-                <uicontrols:PaginationControl
-                    ViewModel="{x:Bind ViewModel}"
-                    HorizontalAlignment="Right"
-                    Margin="0,24,24,16" />
-            </ListView.Footer>
             <ListView.ItemTemplate>
                 <DataTemplate x:DataType="models:Song">
                     <Grid Height="54" ColumnSpacing="12" Background="Transparent">
@@ -402,6 +399,12 @@
                 </DataTemplate>
             </ListView.ItemTemplate>
         </ListView>
+
+        <uicontrols:PaginationControl
+            Grid.Row="2"
+            ViewModel="{x:Bind ViewModel}"
+            HorizontalAlignment="Right"
+            Margin="0,16,24,16" />
 
         <!-- Empty State -->
         <StackPanel

--- a/src/Nagi.WinUI/Styles/Colors.xaml
+++ b/src/Nagi.WinUI/Styles/Colors.xaml
@@ -54,8 +54,9 @@
     <Thickness x:Key="PageHeaderMarginIndented">24,0,24,24</Thickness>
 
     <!-- ListView/GridView Padding -->
-    <Thickness x:Key="SongListViewPadding">24,0,24,132</Thickness>
-    <Thickness x:Key="SongListViewPaddingNoHorizontal">0,0,0,132</Thickness>
+    <Thickness x:Key="SongListViewPadding">24,0,24,0</Thickness>
+    <Thickness x:Key="SongListViewPaddingNoHorizontal">0</Thickness>
+    <Thickness x:Key="SongListViewMargin">0,0,0,132</Thickness>
 
     <!-- Search Box Sizing -->
     <x:Double x:Key="SearchBoxExpandedWidth">300</x:Double>


### PR DESCRIPTION
Keeps pagination fixed at the bottom of paginated views and keeps navigation and scrollbars above the player.

Closes #130