### PR TITLE
feat: allow replacing downloaded lyrics

### DIFF
--- a/src/Nagi.Core/Helpers/FileNameHelper.cs
+++ b/src/Nagi.Core/Helpers/FileNameHelper.cs
@@ -56,6 +56,9 @@ public static class FileNameHelper
         return $"{descriptivePrefix} - {hashSuffix}.lrc";
     }
 
+    public static string GenerateLrcOverrideFileName(string audioFileIdentity) =>
+        $"{GenerateLrcCacheIdentityHash(audioFileIdentity)}.override.lrc";
+
     /// <summary>
     ///     Determines whether a lyrics cache filename belongs to the specified audio file identity.
     ///     Descriptive metadata is intentionally ignored so cached lyrics survive tag edits.
@@ -65,8 +68,10 @@ public static class FileNameHelper
         if (string.IsNullOrWhiteSpace(filePath) || string.IsNullOrWhiteSpace(audioFileIdentity))
             return false;
 
-        var expectedSuffix = $" - {GenerateLrcCacheIdentityHash(audioFileIdentity)}.lrc";
-        return Path.GetFileName(filePath).EndsWith(expectedSuffix, StringComparison.OrdinalIgnoreCase);
+        var hash = GenerateLrcCacheIdentityHash(audioFileIdentity);
+        var fileName = Path.GetFileName(filePath);
+        return fileName.EndsWith($" - {hash}.lrc", StringComparison.OrdinalIgnoreCase)
+               || fileName.Equals($"{hash}.override.lrc", StringComparison.OrdinalIgnoreCase);
     }
 
     private static string GenerateLrcCacheIdentityHash(string audioFileIdentity)

--- a/src/Nagi.Core/Services/Abstractions/ILrcService.cs
+++ b/src/Nagi.Core/Services/Abstractions/ILrcService.cs
@@ -22,6 +22,15 @@ public interface ILrcService
     /// <returns>A ParsedLrc object containing the timed lyrics, or null if parsing fails or the file doesn't exist.</returns>
     Task<ParsedLrc?> GetLyricsAsync(string lrcFilePath);
 
+    /// <summary>Saves a lyrics override in Nagi's cache.</summary>
+    Task SaveLyricsAsync(Song song, string lrcContent);
+
+    /// <summary>Removes cached lyrics without deleting external sidecars.</summary>
+    Task<bool> RemoveCachedLyricsAsync(Song song);
+
+    /// <summary>Returns whether Nagi manages the song's lyrics file.</summary>
+    bool HasCachedLyrics(Song song);
+
     /// <summary>
     ///     Parses a raw LRC string into a ParsedLrc object, which may contain synced or unsynced lyrics.
     /// </summary>

--- a/src/Nagi.Core/Services/Implementations/AtlMetadataService.cs
+++ b/src/Nagi.Core/Services/Implementations/AtlMetadataService.cs
@@ -402,6 +402,10 @@ public class AtlMetadataService : IMetadataService, IDisposable
     /// </summary>
     private async Task<string?> GetLrcPathAsync(string audioFilePath, DateTime audioFileLastWriteTime, string? artist, string? album, string? title, Track track)
     {
+        var overrideFileName = FileNameHelper.GenerateLrcOverrideFileName(audioFilePath);
+        var overridePath = _fileSystem.Combine(_pathConfig.LrcCachePath, overrideFileName);
+        if (_fileSystem.FileExists(overridePath)) return overridePath;
+
         var cacheFileName = FileNameHelper.GenerateLrcCacheFileName(audioFilePath, artist, album, title);
         var cachedLrcPath = _fileSystem.Combine(_pathConfig.LrcCachePath, cacheFileName);
 

--- a/src/Nagi.Core/Services/Implementations/LrcService.cs
+++ b/src/Nagi.Core/Services/Implementations/LrcService.cs
@@ -206,34 +206,69 @@ public class LrcService : ILrcService, IDisposable
         }
     }
 
+    /// <inheritdoc />
+    public Task SaveLyricsAsync(Song song, string lrcContent)
+    {
+        ArgumentNullException.ThrowIfNull(song);
+        ArgumentException.ThrowIfNullOrWhiteSpace(lrcContent);
+        return WriteLyricsCacheAsync(song, lrcContent, true);
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> RemoveCachedLyricsAsync(Song song)
+    {
+        ArgumentNullException.ThrowIfNull(song);
+        if (!HasCachedLyrics(song)) return false;
+
+        var cachedPath = song.LrcFilePath!;
+        var sidecarPath = FindExternalLyricsPath(song.FilePath);
+        if (_fileSystemService.FileExists(cachedPath)) _fileSystemService.DeleteFile(cachedPath);
+
+        song.LrcFilePath = sidecarPath;
+        song.LyricsLastCheckedUtc = DateTime.UtcNow;
+        await _libraryWriter.UpdateSongLrcPathAsync(song.Id, sidecarPath).ConfigureAwait(false);
+        await _libraryWriter.UpdateSongLyricsLastCheckedAsync(song.Id).ConfigureAwait(false);
+        return true;
+    }
+
+    /// <inheritdoc />
+    public bool HasCachedLyrics(Song song)
+    {
+        ArgumentNullException.ThrowIfNull(song);
+        return IsCachePath(song.LrcFilePath);
+    }
+
     private async Task CacheLyricsAsync(Song song, string lrcContent)
     {
         try
         {
-            var cacheIdentity = string.IsNullOrWhiteSpace(song.FilePath) ? song.Id.ToString("N") : song.FilePath;
-            var cacheFileName = FileNameHelper.GenerateLrcCacheFileName(
-                cacheIdentity,
-                song.PrimaryArtistName,
-                song.Album?.Title,
-                song.Title);
-            var cachedLrcPath = _fileSystemService.Combine(_pathConfig.LrcCachePath, cacheFileName);
-
-            await _fileSystemService.WriteAllTextAsync(cachedLrcPath, lrcContent).ConfigureAwait(false);
-            _logger.LogDebug("Cached online lyrics for song {SongId} to {Path}", song.Id, cachedLrcPath);
-
-            // Update the database only if the path has changed
-            if (song.LrcFilePath != cachedLrcPath)
-            {
-                song.LrcFilePath = cachedLrcPath;
-                // We don't persist the full text to 'Lyrics' column here to keep the DB light,
-                // as we rely on the LRC file. The 'Lyrics' column is mostly for unsynced lyrics.
-                await _libraryWriter.UpdateSongLrcPathAsync(song.Id, cachedLrcPath).ConfigureAwait(false);
-            }
+            await WriteLyricsCacheAsync(song, lrcContent, false).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to cache lyrics for song {SongId}", song.Id);
         }
+    }
+
+    private async Task WriteLyricsCacheAsync(Song song, string lrcContent, bool isOverride)
+    {
+        var cacheIdentity = string.IsNullOrWhiteSpace(song.FilePath) ? song.Id.ToString("N") : song.FilePath;
+        var cacheFileName = isOverride
+            ? FileNameHelper.GenerateLrcOverrideFileName(cacheIdentity)
+            : FileNameHelper.GenerateLrcCacheFileName(
+                cacheIdentity, song.PrimaryArtistName, song.Album?.Title, song.Title);
+        var cachedLrcPath = _fileSystemService.Combine(_pathConfig.LrcCachePath, cacheFileName);
+        var previousPath = song.LrcFilePath;
+
+        await _fileSystemService.WriteAllTextAsync(cachedLrcPath, lrcContent).ConfigureAwait(false);
+        _logger.LogDebug("Cached lyrics for song {SongId} to {Path}", song.Id, cachedLrcPath);
+
+        if (previousPath == cachedLrcPath) return;
+        await _libraryWriter.UpdateSongLrcPathAsync(song.Id, cachedLrcPath).ConfigureAwait(false);
+        song.LrcFilePath = cachedLrcPath;
+
+        if (previousPath is not null && IsCachePath(previousPath) && _fileSystemService.FileExists(previousPath))
+            _fileSystemService.DeleteFile(previousPath);
     }
 
     private bool IsLegacyCachePath(Song song)
@@ -242,12 +277,44 @@ public class LrcService : ILrcService, IDisposable
             || string.IsNullOrWhiteSpace(_pathConfig.LrcCachePath))
             return false;
 
-        var cacheRoot = PathCanonicalizer.Normalize(_pathConfig.LrcCachePath).TrimEnd('\\') + "\\";
-        var candidate = PathCanonicalizer.Normalize(song.LrcFilePath);
-        if (!candidate.StartsWith(cacheRoot, StringComparison.OrdinalIgnoreCase)) return false;
+        if (!IsCachePath(song.LrcFilePath)) return false;
 
         var cacheIdentity = string.IsNullOrWhiteSpace(song.FilePath) ? song.Id.ToString("N") : song.FilePath;
+        var candidate = PathCanonicalizer.Normalize(song.LrcFilePath);
         return !FileNameHelper.MatchesLrcCacheIdentity(candidate, cacheIdentity);
+    }
+
+    private bool IsCachePath(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path) || string.IsNullOrWhiteSpace(_pathConfig.LrcCachePath)) return false;
+
+        var cacheRoot = PathCanonicalizer.Normalize(_pathConfig.LrcCachePath).TrimEnd('\\') + "\\";
+        var candidate = PathCanonicalizer.Normalize(path);
+        return candidate.StartsWith(cacheRoot, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private string? FindExternalLyricsPath(string audioFilePath)
+    {
+        if (string.IsNullOrWhiteSpace(audioFilePath)) return null;
+
+        try
+        {
+            var directory = _fileSystemService.GetDirectoryName(audioFilePath);
+            if (string.IsNullOrWhiteSpace(directory)) return null;
+
+            var audioName = _fileSystemService.GetFileNameWithoutExtension(audioFilePath);
+            return _fileSystemService.GetFiles(directory, "*.lrc")
+                       .FirstOrDefault(path => _fileSystemService.GetFileNameWithoutExtension(path)
+                           .Equals(audioName, StringComparison.OrdinalIgnoreCase))
+                   ?? _fileSystemService.GetFiles(directory, "*.txt")
+                       .FirstOrDefault(path => _fileSystemService.GetFileNameWithoutExtension(path)
+                           .Equals(audioName, StringComparison.OrdinalIgnoreCase));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to find external lyrics for {AudioFilePath}.", audioFilePath);
+            return null;
+        }
     }
 
     private Task<string?> LogUnknownProviderAndReturnNull(string providerId)

--- a/src/Nagi.WinUI/Pages/LyricsPage.xaml
+++ b/src/Nagi.WinUI/Pages/LyricsPage.xaml
@@ -35,18 +35,31 @@
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
-        <TextBlock
+        <Grid
             Grid.Row="0"
-            Margin="0,32,0,8"
-            Style="{StaticResource TitleTextBlockStyle}"
-            Text="{x:Bind ViewModel.SongTitle, Mode=OneWay}"
-            Foreground="{StaticResource AppPrimaryColorBrush}"
-            FontWeight="SemiBold"
-            HorizontalAlignment="Center"
-            TextTrimming="CharacterEllipsis"
-            TextWrapping="NoWrap"
-            MaxLines="1"
-            MaxWidth="1200" />
+            Margin="24,32,24,8">
+            <TextBlock
+                Style="{StaticResource TitleTextBlockStyle}"
+                Text="{x:Bind ViewModel.SongTitle, Mode=OneWay}"
+                Foreground="{StaticResource AppPrimaryColorBrush}"
+                FontWeight="SemiBold"
+                HorizontalAlignment="Center"
+                TextTrimming="CharacterEllipsis"
+                TextWrapping="NoWrap"
+                MaxLines="1"
+                MaxWidth="1200" />
+            <Button
+                x:Name="EditLyricsButton"
+                HorizontalAlignment="Right"
+                VerticalAlignment="Center"
+                Style="{StaticResource SubtleButtonStyle}"
+                IsEnabled="{x:Bind ViewModel.CanEditLyrics, Mode=OneWay}"
+                Click="EditLyricsButton_Click"
+                AutomationProperties.Name="{x:Bind resources:Strings.LyricsPage_EditLyrics_ToolTip, Mode=OneTime}"
+                ToolTipService.ToolTip="{x:Bind resources:Strings.LyricsPage_EditLyrics_ToolTip, Mode=OneTime}">
+                <FontIcon Glyph="&#xE70F;" />
+            </Button>
+        </Grid>
 
         <ProgressBar
             x:Name="LyricsProgressBar"

--- a/src/Nagi.WinUI/Pages/LyricsPage.xaml.cs
+++ b/src/Nagi.WinUI/Pages/LyricsPage.xaml.cs
@@ -95,6 +95,66 @@ public sealed partial class LyricsPage : Page
         }
     }
 
+    private async void EditLyricsButton_Click(object sender, RoutedEventArgs e)
+    {
+        var songId = ViewModel.CurrentSongId;
+        if (songId is null) return;
+
+        var originalLyrics = ViewModel.EditableLyrics;
+        var editor = new TextBox
+        {
+            AcceptsReturn = true,
+            Text = originalLyrics,
+            PlaceholderText = Nagi.WinUI.Resources.Strings.LyricsPage_EditLyrics_Placeholder,
+            TextWrapping = TextWrapping.Wrap,
+            MinWidth = 520,
+            Height = 360
+        };
+        ScrollViewer.SetVerticalScrollBarVisibility(editor, ScrollBarVisibility.Auto);
+        var dialog = new ContentDialog
+        {
+            Title = Nagi.WinUI.Resources.Strings.LyricsPage_EditLyrics_Title,
+            Content = editor,
+            PrimaryButtonText = Nagi.WinUI.Resources.Strings.LyricsPage_EditLyrics_Save,
+            SecondaryButtonText = ViewModel.CanRemoveLyrics
+                ? Nagi.WinUI.Resources.Strings.LyricsPage_EditLyrics_Remove
+                : string.Empty,
+            CloseButtonText = Nagi.WinUI.Resources.Strings.Generic_Cancel,
+            DefaultButton = ContentDialogButton.Primary,
+            XamlRoot = XamlRoot
+        };
+
+        void UpdateSaveButton() => dialog.IsPrimaryButtonEnabled =
+            !string.IsNullOrWhiteSpace(editor.Text)
+            && editor.Text.ReplaceLineEndings("\n") != originalLyrics.ReplaceLineEndings("\n");
+
+        editor.TextChanged += (_, _) => UpdateSaveButton();
+        UpdateSaveButton();
+        DialogThemeHelper.ApplyThemeOverrides(dialog);
+
+        try
+        {
+            var result = await dialog.ShowAsync();
+            if (result == ContentDialogResult.Primary)
+                await ViewModel.SaveLyricsAsync(songId.Value, editor.Text.ReplaceLineEndings());
+            else if (result == ContentDialogResult.Secondary)
+                await ViewModel.RemoveLyricsAsync(songId.Value);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to update lyrics.");
+            var errorDialog = new ContentDialog
+            {
+                Title = Nagi.WinUI.Resources.Strings.LyricsPage_EditLyrics_Error_Title,
+                Content = Nagi.WinUI.Resources.Strings.LyricsPage_EditLyrics_Error_Message,
+                CloseButtonText = Nagi.WinUI.Resources.Strings.Generic_OK,
+                XamlRoot = XamlRoot
+            };
+            DialogThemeHelper.ApplyThemeOverrides(errorDialog);
+            await errorDialog.ShowAsync();
+        }
+    }
+
     private void OnPageUnloaded(object sender, RoutedEventArgs e)
     {
         _isUnloaded = true;

--- a/src/Nagi.WinUI/Resources/Strings.cs
+++ b/src/Nagi.WinUI/Resources/Strings.cs
@@ -557,6 +557,13 @@ public static class Strings
     public static string LibraryPage_EmptyState_Subtitle => GetString("LibraryPage_EmptyState_Subtitle");
     public static string LyricsPage_NoLyrics_Title => GetString("LyricsPage_NoLyrics_Title");
     public static string LyricsPage_NoLyrics_Subtitle => GetString("LyricsPage_NoLyrics_Subtitle");
+    public static string LyricsPage_EditLyrics_ToolTip => GetString("LyricsPage_EditLyrics_ToolTip");
+    public static string LyricsPage_EditLyrics_Title => GetString("LyricsPage_EditLyrics_Title");
+    public static string LyricsPage_EditLyrics_Placeholder => GetString("LyricsPage_EditLyrics_Placeholder");
+    public static string LyricsPage_EditLyrics_Save => GetString("LyricsPage_EditLyrics_Save");
+    public static string LyricsPage_EditLyrics_Remove => GetString("LyricsPage_EditLyrics_Remove");
+    public static string LyricsPage_EditLyrics_Error_Title => GetString("LyricsPage_EditLyrics_Error_Title");
+    public static string LyricsPage_EditLyrics_Error_Message => GetString("LyricsPage_EditLyrics_Error_Message");
     public static string OnboardingPage_Welcome_Title => GetString("OnboardingPage_Welcome_Title");
     public static string OnboardingPage_AddFolderButton_ToolTip => GetString("OnboardingPage_AddFolderButton_ToolTip");
     public static string OnboardingPage_AddFolderButton_Content => GetString("OnboardingPage_AddFolderButton_Content");

--- a/src/Nagi.WinUI/Resources/Strings.resx
+++ b/src/Nagi.WinUI/Resources/Strings.resx
@@ -1388,6 +1388,27 @@ Error: {1}</value>
   <data name="LyricsPage_NoLyrics_Subtitle" xml:space="preserve">
     <value>Try another song</value>
   </data>
+  <data name="LyricsPage_EditLyrics_ToolTip" xml:space="preserve">
+    <value>Edit or replace lyrics</value>
+  </data>
+  <data name="LyricsPage_EditLyrics_Title" xml:space="preserve">
+    <value>Edit lyrics</value>
+  </data>
+  <data name="LyricsPage_EditLyrics_Placeholder" xml:space="preserve">
+    <value>Paste plain text or timestamped LRC lyrics</value>
+  </data>
+  <data name="LyricsPage_EditLyrics_Save" xml:space="preserve">
+    <value>Save</value>
+  </data>
+  <data name="LyricsPage_EditLyrics_Remove" xml:space="preserve">
+    <value>Remove saved lyrics</value>
+  </data>
+  <data name="LyricsPage_EditLyrics_Error_Title" xml:space="preserve">
+    <value>Lyrics could not be updated</value>
+  </data>
+  <data name="LyricsPage_EditLyrics_Error_Message" xml:space="preserve">
+    <value>Nagi could not save the lyrics. Check the log for details and try again.</value>
+  </data>
   <data name="OnboardingPage_Welcome_Title" xml:space="preserve">
     <value>Welcome to Nagi</value>
   </data>

--- a/src/Nagi.WinUI/ViewModels/LyricsPageViewModel.cs
+++ b/src/Nagi.WinUI/ViewModels/LyricsPageViewModel.cs
@@ -41,6 +41,7 @@ public partial class LyricsPageViewModel : ObservableObject, IDisposable
     private LyricLine? _optimisticallySetLine;
     private DateTime _optimisticSetTimestamp;
     private ParsedLrc? _parsedLrc;
+    private Song? _currentSong;
 
     public LyricsPageViewModel(
         IMusicPlaybackService playbackService,
@@ -104,6 +105,11 @@ public partial class LyricsPageViewModel : ObservableObject, IDisposable
     [NotifyPropertyChangedFor(nameof(ShowNoLyricsMessage))]
     public partial bool IsLoading { get; set; }
 
+    [ObservableProperty] public partial bool CanEditLyrics { get; set; }
+    [ObservableProperty] public partial bool CanRemoveLyrics { get; set; }
+    [ObservableProperty] public partial string EditableLyrics { get; set; } = string.Empty;
+    public Guid? CurrentSongId => _currentSong?.Id;
+
     /// <summary>
     ///     True when the timed lyrics ListView should be displayed.
     /// </summary>
@@ -161,6 +167,27 @@ public partial class LyricsPageViewModel : ObservableObject, IDisposable
         await _playbackService.SeekAsync(targetTime);
     }
 
+    public async Task SaveLyricsAsync(Guid songId, string lyrics)
+    {
+        var song = _currentSong?.Id == songId
+            ? _currentSong
+            : await _libraryReader.GetSongWithFullDataAsync(songId).ConfigureAwait(false);
+        if (song is null || string.IsNullOrWhiteSpace(lyrics)) return;
+
+        await _lrcService.SaveLyricsAsync(song, lyrics).ConfigureAwait(false);
+        if (_currentSong?.Id == song.Id) await UpdateForTrack(song).ConfigureAwait(false);
+    }
+
+    public async Task RemoveLyricsAsync(Guid songId)
+    {
+        var song = _currentSong?.Id == songId
+            ? _currentSong
+            : await _libraryReader.GetSongWithFullDataAsync(songId).ConfigureAwait(false);
+        if (song is null || !await _lrcService.RemoveCachedLyricsAsync(song).ConfigureAwait(false)) return;
+
+        if (_currentSong?.Id == song.Id) await UpdateForTrack(song).ConfigureAwait(false);
+    }
+
     private void OnPlaybackServicePositionChanged()
     {
         UpdateCurrentLineFromPosition(_playbackService.CurrentPosition);
@@ -206,6 +233,8 @@ public partial class LyricsPageViewModel : ObservableObject, IDisposable
 
     private async Task UpdateForTrack(Song? song)
     {
+        _currentSong = song;
+
         // Cancel any previous lyrics fetch operation to prevent stale data when skipping songs
         CancellationToken cancellationToken;
         lock (_lyricsFetchLock)
@@ -230,6 +259,9 @@ public partial class LyricsPageViewModel : ObservableObject, IDisposable
             CurrentPosition = TimeSpan.Zero;
             HasLyrics = false;
             HasUnsyncedLyrics = false;
+            CanEditLyrics = false;
+            CanRemoveLyrics = song is not null && _lrcService.HasCachedLyrics(song);
+            EditableLyrics = string.Empty;
 
             if (song is null)
             {
@@ -277,6 +309,9 @@ public partial class LyricsPageViewModel : ObservableObject, IDisposable
                 {
                     if (cancellationToken.IsCancellationRequested || _isDisposed) return;
                     _parsedLrc = displayLrc;
+                    EditableLyrics = localLrc.RawUnsyncedLyrics ?? string.Empty;
+                    CanEditLyrics = true;
+                    CanRemoveLyrics = _lrcService.HasCachedLyrics(song);
                     LyricLines.AddRange(displayLrc.Lines);
                     HasLyrics = true;
                     IsLoading = false;
@@ -298,6 +333,9 @@ public partial class LyricsPageViewModel : ObservableObject, IDisposable
                     {
                         if (cancellationToken.IsCancellationRequested || _isDisposed) return;
                         _parsedLrc = displayLrc;
+                        EditableLyrics = fullSong.Lyrics;
+                        CanEditLyrics = true;
+                        CanRemoveLyrics = _lrcService.HasCachedLyrics(song);
                         LyricLines.AddRange(displayLrc.Lines);
                         HasLyrics = true;
                         IsLoading = false;
@@ -312,6 +350,9 @@ public partial class LyricsPageViewModel : ObservableObject, IDisposable
                 {
                     if (cancellationToken.IsCancellationRequested || _isDisposed) return;
                     UnsyncedLyricLines.AddRange(embeddedLines);
+                    EditableLyrics = fullSong.Lyrics;
+                    CanEditLyrics = true;
+                    CanRemoveLyrics = _lrcService.HasCachedLyrics(song);
                     HasUnsyncedLyrics = true;
                     IsLoading = false;
                 });
@@ -330,6 +371,9 @@ public partial class LyricsPageViewModel : ObservableObject, IDisposable
                 {
                     if (cancellationToken.IsCancellationRequested || _isDisposed) return;
                     _parsedLrc = displayLrc;
+                    EditableLyrics = parsedLrc.RawUnsyncedLyrics ?? string.Empty;
+                    CanEditLyrics = true;
+                    CanRemoveLyrics = _lrcService.HasCachedLyrics(song);
                     LyricLines.AddRange(displayLrc.Lines);
                     HasLyrics = true;
                     IsLoading = false;
@@ -346,6 +390,9 @@ public partial class LyricsPageViewModel : ObservableObject, IDisposable
                 {
                     if (cancellationToken.IsCancellationRequested || _isDisposed) return;
                     UnsyncedLyricLines.AddRange(unsyncedLines);
+                    EditableLyrics = parsedLrc.RawUnsyncedLyrics;
+                    CanEditLyrics = true;
+                    CanRemoveLyrics = _lrcService.HasCachedLyrics(song);
                     HasUnsyncedLyrics = true;
                     IsLoading = false;
                 });
@@ -356,6 +403,7 @@ public partial class LyricsPageViewModel : ObservableObject, IDisposable
                 _dispatcherService.TryEnqueue(() =>
                 {
                     if (cancellationToken.IsCancellationRequested || _isDisposed) return;
+                    CanEditLyrics = true;
                     IsLoading = false;
                 });
             }
@@ -368,7 +416,11 @@ public partial class LyricsPageViewModel : ObservableObject, IDisposable
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to fetch lyrics for track '{SongTitle}'", song.Title);
-            _dispatcherService.TryEnqueue(() => IsLoading = false);
+            _dispatcherService.TryEnqueue(() =>
+            {
+                CanEditLyrics = true;
+                IsLoading = false;
+            });
         }
     }
 

--- a/tests/Nagi.Core.Tests/AtlMetadataServiceTests.cs
+++ b/tests/Nagi.Core.Tests/AtlMetadataServiceTests.cs
@@ -309,6 +309,25 @@ public class AtlMetadataServiceTests : IDisposable
         await _fileSystem.DidNotReceive().WriteAllTextAsync(Arg.Any<string>(), Arg.Any<string>());
     }
 
+    [Fact]
+    public async Task GetLrcPathAsync_WithOlderOverride_ReturnsOverride()
+    {
+        var audioFilePath = CreateTestAudioFile("override.mp3", track =>
+        {
+            track.Title = "Override Song";
+            track.Artist = "Override Artist";
+        });
+        _fileSystem.GetFileInfo(audioFilePath).Returns(new FileInfo(audioFilePath));
+        var expectedPath = Path.Combine(LrcCachePath,
+            FileNameHelper.GenerateLrcOverrideFileName(audioFilePath));
+        _fileSystem.FileExists(expectedPath).Returns(true);
+
+        var result = await _metadataService.ExtractMetadataAsync(audioFilePath);
+
+        result.LrcFilePath.Should().Be(expectedPath);
+        _fileSystem.DidNotReceive().GetLastWriteTimeUtc(expectedPath);
+    }
+
     /// <summary>
     ///     Verifies that the service can find an external LRC file located in the same
     ///     directory as the audio file when no embedded or cached lyrics are available.

--- a/tests/Nagi.Core.Tests/LrcServiceTests.cs
+++ b/tests/Nagi.Core.Tests/LrcServiceTests.cs
@@ -194,6 +194,80 @@ public class LrcServiceTests
         result.Should().BeNull();
     }
 
+    [Fact]
+    public async Task RemoveCachedLyricsAsync_DeletesOnlyManagedFileAndPreventsRedownload()
+    {
+        const string cacheRoot = @"C:\cache\lrc";
+        var cachedPath = Path.Combine(cacheRoot, "song.lrc");
+        var song = new Song { Id = Guid.NewGuid(), LrcFilePath = cachedPath };
+        _pathConfig.LrcCachePath.Returns(cacheRoot);
+        _fileSystem.FileExists(cachedPath).Returns(true);
+        _settingsService.GetFetchOnlineLyricsEnabledAsync().Returns(true);
+
+        var removed = await _lrcService.RemoveCachedLyricsAsync(song);
+        var result = await _lrcService.GetLyricsAsync(song);
+
+        removed.Should().BeTrue();
+        result.Should().BeNull();
+        _fileSystem.Received(1).DeleteFile(cachedPath);
+        await _libraryWriter.Received(1).UpdateSongLrcPathAsync(song.Id, null);
+        await _libraryWriter.Received(1).UpdateSongLyricsLastCheckedAsync(song.Id);
+        await _onlineLyricsService.DidNotReceive().GetLyricsAsync(
+            Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>());
+        song.LrcFilePath.Should().BeNull();
+        song.LyricsLastCheckedUtc.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task SaveAndRemoveLyrics_WithExternalSidecar_RestoresSidecar()
+    {
+        const string cacheRoot = @"C:\cache\lrc";
+        const string externalPath = @"C:\Music\Song.lrc";
+        const string content = "[00:01.00]Correct lyrics";
+        var song = new Song
+        {
+            Id = Guid.NewGuid(),
+            FilePath = @"C:\Music\Song.flac",
+            Title = "Song",
+            PrimaryArtistName = "Artist",
+            LrcFilePath = externalPath,
+            Album = new Album { Title = "Album" }
+        };
+        var expectedPath = Path.Combine(cacheRoot, FileNameHelper.GenerateLrcOverrideFileName(song.FilePath));
+        _pathConfig.LrcCachePath.Returns(cacheRoot);
+        _fileSystem.Combine(Arg.Any<string[]>()).Returns(call => Path.Combine(call.Arg<string[]>()!));
+        _fileSystem.GetDirectoryName(song.FilePath).Returns(@"C:\Music");
+        _fileSystem.GetFileNameWithoutExtension(song.FilePath).Returns("Song");
+        _fileSystem.GetFileNameWithoutExtension(externalPath).Returns("Song");
+        _fileSystem.GetFiles(@"C:\Music", "*.lrc").Returns([externalPath]);
+        _fileSystem.FileExists(expectedPath).Returns(true);
+
+        await _lrcService.SaveLyricsAsync(song, content);
+        var removed = await _lrcService.RemoveCachedLyricsAsync(song);
+
+        removed.Should().BeTrue();
+        await _fileSystem.Received(1).WriteAllTextAsync(expectedPath, content);
+        await _fileSystem.DidNotReceive().WriteAllTextAsync(externalPath, Arg.Any<string>());
+        _fileSystem.Received(1).DeleteFile(expectedPath);
+        _fileSystem.DidNotReceive().DeleteFile(externalPath);
+        await _libraryWriter.Received(1).UpdateSongLrcPathAsync(song.Id, expectedPath);
+        await _libraryWriter.Received(1).UpdateSongLrcPathAsync(song.Id, externalPath);
+        song.LrcFilePath.Should().Be(externalPath);
+    }
+
+    [Fact]
+    public async Task RemoveCachedLyricsAsync_WithExternalSidecar_DoesNotDeleteFile()
+    {
+        var song = new Song { Id = Guid.NewGuid(), LrcFilePath = @"C:\Music\Song.lrc" };
+        _pathConfig.LrcCachePath.Returns(@"C:\cache\lrc");
+
+        var removed = await _lrcService.RemoveCachedLyricsAsync(song);
+
+        removed.Should().BeFalse();
+        _fileSystem.DidNotReceive().DeleteFile(Arg.Any<string>());
+        await _libraryWriter.DidNotReceive().UpdateSongLrcPathAsync(Arg.Any<Guid>(), Arg.Any<string?>());
+    }
+
     #endregion
 
     #region GetCurrentLine Tests


### PR DESCRIPTION
Adds cache-backed lyric adding, editing, and removal without modifying external sidecars. Overrides survive metadata rescans.

Closes #131