### PR TITLE
fix: keep large library operations responsive

### DIFF
--- a/src/Nagi.Core/Data/Migrations/20260830194706_OptimizeSongTitleSortIndexes.Designer.cs
+++ b/src/Nagi.Core/Data/Migrations/20260830194706_OptimizeSongTitleSortIndexes.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nagi.Core.Data;
 
@@ -10,12 +11,14 @@ using Nagi.Core.Data;
 namespace Nagi.Core.Data.Migrations
 {
     [DbContext(typeof(MusicDbContext))]
-    partial class MusicDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260830194706_OptimizeSongTitleSortIndexes")]
+    partial class OptimizeSongTitleSortIndexes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder.HasAnnotation("ProductVersion", "10.0.7");
+            modelBuilder.HasAnnotation("ProductVersion", "10.0.9");
 
             modelBuilder.Entity("GenreSong", b =>
                 {

--- a/src/Nagi.Core/Data/Migrations/20260830194706_OptimizeSongTitleSortIndexes.cs
+++ b/src/Nagi.Core/Data/Migrations/20260830194706_OptimizeSongTitleSortIndexes.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nagi.Core.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class OptimizeSongTitleSortIndexes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Songs_SortTitle",
+                table: "Songs");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Songs_Title",
+                table: "Songs");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Songs_SortTitle_PrimaryArtistSortName_Id",
+                table: "Songs",
+                columns: new[] { "SortTitle", "PrimaryArtistSortName", "Id" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Songs_Title_PrimaryArtistName_Id",
+                table: "Songs",
+                columns: new[] { "Title", "PrimaryArtistName", "Id" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Songs_SortTitle_PrimaryArtistSortName_Id",
+                table: "Songs");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Songs_Title_PrimaryArtistName_Id",
+                table: "Songs");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Songs_SortTitle",
+                table: "Songs",
+                column: "SortTitle");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Songs_Title",
+                table: "Songs",
+                column: "Title");
+        }
+    }
+}

--- a/src/Nagi.Core/Data/MusicDbContext.cs
+++ b/src/Nagi.Core/Data/MusicDbContext.cs
@@ -50,8 +50,8 @@ public class MusicDbContext : DbContext
             entity.Property(s => s.FilePath).UseCollation("NOCASE");
             entity.Property(s => s.DirectoryPath).UseCollation("NOCASE");
 
-            entity.HasIndex(s => s.Title);
-            entity.HasIndex(s => s.SortTitle);
+            entity.HasIndex(s => new { s.Title, s.PrimaryArtistName, s.Id });
+            entity.HasIndex(s => new { s.SortTitle, s.PrimaryArtistSortName, s.Id });
             entity.HasIndex(s => s.ArtistName);
             entity.HasIndex(s => s.PrimaryArtistName);
             entity.HasIndex(s => s.PrimaryArtistSortName);

--- a/src/Nagi.WinUI/ViewModels/AlbumViewModel.cs
+++ b/src/Nagi.WinUI/ViewModels/AlbumViewModel.cs
@@ -89,8 +89,8 @@ public partial class AlbumViewModel : PagedListViewModelBase<Album>
     protected override async Task<PagedResult<Album>> LoadPageItemsAsync(int pageNumber, int pageSize, CancellationToken token)
     {
         var pagedResult = IsSearchActive
-            ? await _libraryService.SearchAlbumsPagedAsync(SearchTerm, pageNumber, pageSize)
-            : await _libraryService.GetAllAlbumsPagedAsync(pageNumber, pageSize, CurrentSortOrder);
+            ? await _libraryService.SearchAlbumsPagedAsync(SearchTerm, pageNumber, pageSize, token)
+            : await _libraryService.GetAllAlbumsPagedAsync(pageNumber, pageSize, CurrentSortOrder, token);
 
         token.ThrowIfCancellationRequested();
 

--- a/src/Nagi.WinUI/ViewModels/AlbumViewViewModel.cs
+++ b/src/Nagi.WinUI/ViewModels/AlbumViewViewModel.cs
@@ -77,7 +77,8 @@ public partial class AlbumViewViewModel : SongListViewModelBase
         else
             result = await _libraryReader.GetSongsByAlbumIdPagedAsync(_albumId, pageNumber, pageSize, sortOrder, cancellationToken);
 
-        if (pageNumber == 1) UpdateAlbumDetails(result);
+        if (pageNumber == 1)
+            _dispatcherService.TryEnqueue(() => UpdateAlbumDetails(result));
 
         return result;
     }
@@ -207,7 +208,9 @@ public partial class AlbumViewViewModel : SongListViewModelBase
     {
         try
         {
-            var duration = await _libraryReader.GetSearchTotalDurationInAlbumAsync(_albumId, searchTerm, cancellationToken);
+            var duration = await Task.Run(
+                () => _libraryReader.GetSearchTotalDurationInAlbumAsync(_albumId, searchTerm, cancellationToken),
+                cancellationToken).ConfigureAwait(false);
 
             if (!cancellationToken.IsCancellationRequested)
             {

--- a/src/Nagi.WinUI/ViewModels/ArtistViewModel.cs
+++ b/src/Nagi.WinUI/ViewModels/ArtistViewModel.cs
@@ -93,8 +93,8 @@ public partial class ArtistViewModel : PagedListViewModelBase<Artist>
     protected override async Task<PagedResult<Artist>> LoadPageItemsAsync(int pageNumber, int pageSize, CancellationToken token)
     {
         var pagedResult = IsSearchActive
-            ? await _libraryService.SearchArtistsPagedAsync(SearchTerm, pageNumber, pageSize)
-            : await _libraryService.GetAllArtistsPagedAsync(pageNumber, pageSize, CurrentSortOrder);
+            ? await _libraryService.SearchArtistsPagedAsync(SearchTerm, pageNumber, pageSize, token)
+            : await _libraryService.GetAllArtistsPagedAsync(pageNumber, pageSize, CurrentSortOrder, token);
 
         token.ThrowIfCancellationRequested();
         return pagedResult ?? new PagedResult<Artist>();

--- a/src/Nagi.WinUI/ViewModels/FolderSongListViewModel.cs
+++ b/src/Nagi.WinUI/ViewModels/FolderSongListViewModel.cs
@@ -68,29 +68,6 @@ public partial class FolderSongListViewModel : SongListViewModelBase
     [ObservableProperty]
     public partial bool IsAtRootLevel { get; set; } = true;
 
-    public override int SelectedItemsCount
-    {
-        get
-        {
-            try
-            {
-                _stateLock.EnterReadLock();
-                try
-                {
-                    return SelectionState.GetSelectedCount(_fullSongIdList.Count + _totalFolderCount);
-                }
-                finally
-                {
-                    _stateLock.ExitReadLock();
-                }
-            }
-            catch (ObjectDisposedException)
-            {
-                return 0;
-            }
-        }
-    }
-
     // -------------------------------------------------------------------------
     // Initialization
     // -------------------------------------------------------------------------
@@ -267,10 +244,7 @@ public partial class FolderSongListViewModel : SongListViewModelBase
     // Base class overrides
     // -------------------------------------------------------------------------
 
-    /// <summary>
-    ///     Overrides the base refresh to resolve the parent folder, fetch counts and song IDs in parallel,
-    ///     then load page 1 using the combined math.
-    /// </summary>
+    /// <summary>Loads page 1 after resolving the current folder and item counts.</summary>
     public override async Task RefreshOrSortSongsAsync(string? sortOrderString = null, CancellationToken manualToken = default)
     {
         lock (_loadLock)
@@ -295,6 +269,7 @@ public partial class FolderSongListViewModel : SongListViewModelBase
         }
 
         UpdateSortOrderButtonText(CurrentSortOrder);
+        ClearFullSongIds();
 
         _pagedLoadCts?.Cancel();
         _pagedLoadCts?.Dispose();
@@ -309,17 +284,8 @@ public partial class FolderSongListViewModel : SongListViewModelBase
             var parentFolderId = await ResolveCurrentParentFolderIdAsync().ConfigureAwait(false);
             if (!parentFolderId.HasValue || token.IsCancellationRequested) return;
 
-            // Parallel: total folder count + all song IDs (for Play All). Both are cheap COUNT/ID queries.
-            var countTask = FetchTotalFolderCountAsync(parentFolderId.Value, token);
-            var idsTask = LoadAllSongIdsAsync(CurrentSortOrder, token);
-            await Task.WhenAll(countTask, idsTask).ConfigureAwait(false);
+            _totalFolderCount = await FetchTotalFolderCountAsync(parentFolderId.Value, token).ConfigureAwait(false);
             if (token.IsCancellationRequested) return;
-
-            _totalFolderCount = countTask.Result;
-
-            _stateLock.EnterWriteLock();
-            try { _fullSongIdList = idsTask.Result; }
-            finally { _stateLock.ExitWriteLock(); }
 
             await LoadCombinedPageAsync(1, parentFolderId.Value, _totalFolderCount, token).ConfigureAwait(false);
         }
@@ -563,9 +529,8 @@ public partial class FolderSongListViewModel : SongListViewModelBase
 
     protected override async Task<List<Guid>> GetCurrentSelectionIdsAsync()
     {
-        // SelectionState.GetSelectedIds already handles both select-all and explicit-selection modes
-        // correctly for songs. We start from the full song ID list (all pages).
-        var selectedIds = SelectionState.GetSelectedIds(_fullSongIdList).ToList();
+        var allSongIds = await GetFullSongIdsAsync();
+        var selectedIds = SelectionState.GetSelectedIds(allSongIds).ToList();
         var resultSet = new HashSet<Guid>(selectedIds);
 
         // For explicitly selected folders (non-select-all mode), we expand them into their song IDs.

--- a/src/Nagi.WinUI/ViewModels/PagedListViewModelBase.cs
+++ b/src/Nagi.WinUI/ViewModels/PagedListViewModelBase.cs
@@ -252,21 +252,26 @@ public abstract partial class PagedListViewModelBase<TItem> : SearchableViewMode
             var pageToLoad = CurrentPage;
             var pageSize = SongsPerPage;
 
-            var auxTask = OnAuxiliaryLoadAsync(token);
-            var pageTask = LoadPageItemsAsync(pageToLoad, pageSize, token);
-            await Task.WhenAll(auxTask, pageTask).ConfigureAwait(false);
-            token.ThrowIfCancellationRequested();
-
-            var pagedResult = pageTask.Result;
-
-            // Past-end clamp: if the requested page exceeds the result set (e.g. items removed),
-            // jump back to the last valid page and refetch.
-            var totalPages = Math.Max(1, pagedResult.TotalPages);
-            if (pageToLoad > totalPages && pagedResult.TotalCount > 0)
+            // SQLite's async APIs still perform native I/O, so keep page loads off the UI thread.
+            var pagedResult = await Task.Run(async () =>
             {
-                pagedResult = await LoadPageItemsAsync(totalPages, pageSize, token).ConfigureAwait(false);
+                var auxTask = OnAuxiliaryLoadAsync(token);
+                var pageTask = LoadPageItemsAsync(pageToLoad, pageSize, token);
+                await Task.WhenAll(auxTask, pageTask).ConfigureAwait(false);
                 token.ThrowIfCancellationRequested();
-            }
+
+                var result = pageTask.Result;
+
+                // Clamp pages past the end after items are removed.
+                var totalPages = Math.Max(1, result.TotalPages);
+                if (pageToLoad > totalPages && result.TotalCount > 0)
+                {
+                    result = await LoadPageItemsAsync(totalPages, pageSize, token).ConfigureAwait(false);
+                    token.ThrowIfCancellationRequested();
+                }
+
+                return result;
+            }, token);
 
             ProcessPagedResult(pagedResult, token);
 

--- a/src/Nagi.WinUI/ViewModels/PlaylistSongListViewModel.cs
+++ b/src/Nagi.WinUI/ViewModels/PlaylistSongListViewModel.cs
@@ -21,6 +21,8 @@ namespace Nagi.WinUI.ViewModels;
 /// </summary>
 public partial class PlaylistSongListViewModel : SongListViewModelBase
 {
+    protected override bool PrefetchSongIds => true;
+
     private Guid? _currentPlaylistId;
     private CancellationTokenSource? _saveOrderCts;
 
@@ -275,8 +277,7 @@ public partial class PlaylistSongListViewModel : SongListViewModelBase
             movedSong.Order = newOrder;
 
             // Update the master ID list for playback consistency
-            _stateLock.EnterWriteLock();
-            try
+            lock (_fullSongIdsLock)
             {
                 var oldIndex = _fullSongIdList.IndexOf(movedSong.Id);
                 if (oldIndex >= 0 && oldIndex != newIndex)
@@ -285,10 +286,6 @@ public partial class PlaylistSongListViewModel : SongListViewModelBase
                     var insertIndex = Math.Min(newIndex, _fullSongIdList.Count);
                     _fullSongIdList.Insert(insertIndex, movedSong.Id);
                 }
-            }
-            finally
-            {
-                _stateLock.ExitWriteLock();
             }
 
             // Save to database with proper error handling
@@ -324,8 +321,7 @@ public partial class PlaylistSongListViewModel : SongListViewModelBase
 
         if (e.Action == NotifyCollectionChangedAction.Remove)
         {
-            _stateLock.EnterWriteLock();
-            try
+            lock (_fullSongIdsLock)
             {
                 if (e.OldItems != null)
                 {
@@ -334,10 +330,6 @@ public partial class PlaylistSongListViewModel : SongListViewModelBase
                         if (item is Song song) _fullSongIdList.Remove(song.Id);
                     }
                 }
-            }
-            finally
-            {
-                _stateLock.ExitWriteLock();
             }
         }
     }
@@ -372,7 +364,10 @@ public partial class PlaylistSongListViewModel : SongListViewModelBase
                         _logger.LogDebug("Playlist order normalization aborted: Active playlist changed.");
                         return;
                     }
-                    songIds = _fullSongIdList.ToList();
+                    lock (_fullSongIdsLock)
+                    {
+                        songIds = _fullSongIdList.ToList();
+                    }
                 }
                 finally
                 {

--- a/src/Nagi.WinUI/ViewModels/SongListViewModelBase.cs
+++ b/src/Nagi.WinUI/ViewModels/SongListViewModelBase.cs
@@ -19,10 +19,7 @@ using Nagi.WinUI.Helpers;
 namespace Nagi.WinUI.ViewModels;
 
 /// <summary>
-///     Base class for song list view models. Adds selection, playback commands, the
-///     full ID list (used for "Play All" without holding every <see cref="Song"/> in
-///     memory), and infinite-scroll auto-loading when
-///     <see cref="PagedListViewModelBase{TItem}.IsPaginationEnabled"/> is false.
+///     Adds selection, playback, and infinite scrolling to song lists.
 /// </summary>
 public abstract partial class SongListViewModelBase : PagedListViewModelBase<Song>
 {
@@ -44,8 +41,13 @@ public abstract partial class SongListViewModelBase : PagedListViewModelBase<Son
     /// </summary>
     [ObservableProperty] public partial Guid? CurrentPlayingSongId { get; set; }
 
-    // For paged views, this holds all song IDs to enable "Play All" without loading all song objects into memory.
+    // Loaded on demand unless a view requires it for editing.
+    protected readonly object _fullSongIdsLock = new();
     protected List<Guid> _fullSongIdList = new();
+    private Task<List<Guid>>? _fullSongIdLoadTask;
+    private int _fullSongIdGeneration;
+
+    protected virtual bool PrefetchSongIds => false;
 
     // Owned by the song-base's <see cref="LoadPageAsync"/> envelope (Next/Previous reload that skips
     // the auxiliary ID fetch). Distinct from the base's internal page CTS, which gates LoadAsync.
@@ -160,7 +162,7 @@ public abstract partial class SongListViewModelBase : PagedListViewModelBase<Son
             _stateLock.EnterReadLock();
             try
             {
-                return SelectionState.GetSelectedCount(_fullSongIdList.Count);
+                return SelectionState.GetSelectedCount(TotalItemCount);
             }
             finally
             {
@@ -178,6 +180,7 @@ public abstract partial class SongListViewModelBase : PagedListViewModelBase<Son
 
     protected virtual void OnCurrentSortOrderChangedInternal(SongSortOrder oldOrder, SongSortOrder newOrder)
     {
+        ClearFullSongIds();
     }
 
     [ObservableProperty] public partial string CurrentSortOrderText { get; set; } = string.Empty;
@@ -209,6 +212,7 @@ public abstract partial class SongListViewModelBase : PagedListViewModelBase<Son
     protected override void OnSearchTermChangedInternal(string value)
     {
         if (HasSelectedSongs) DeselectAll();
+        ClearFullSongIds();
     }
 
     protected override async Task ExecuteSearchAsync(CancellationToken token)
@@ -226,14 +230,79 @@ public abstract partial class SongListViewModelBase : PagedListViewModelBase<Son
         return LoadSongsPagedAsync(pageNumber, pageSize, CurrentSortOrder, token);
     }
 
-    /// <summary>Run the full ID fetch (used by Play All) in parallel with the page query.</summary>
+    /// <summary>Refreshes the playback ID cache when a view requires it.</summary>
     protected override async Task OnAuxiliaryLoadAsync(CancellationToken token)
     {
+        var generation = ClearFullSongIds();
+        if (IsSearchActive || !PrefetchSongIds)
+        {
+            return;
+        }
+
         var ids = await LoadAllSongIdsAsync(CurrentSortOrder, token).ConfigureAwait(false);
         token.ThrowIfCancellationRequested();
-        _stateLock.EnterWriteLock();
-        try { _fullSongIdList = ids; }
-        finally { _stateLock.ExitWriteLock(); }
+        StoreFullSongIds(ids, generation);
+    }
+
+    protected int ClearFullSongIds()
+    {
+        lock (_fullSongIdsLock)
+        {
+            _fullSongIdList = new List<Guid>();
+            _fullSongIdLoadTask = null;
+            return ++_fullSongIdGeneration;
+        }
+    }
+
+    private void StoreFullSongIds(List<Guid> ids, int generation)
+    {
+        lock (_fullSongIdsLock)
+        {
+            if (_isDisposed || generation != _fullSongIdGeneration) return;
+            _fullSongIdList = ids;
+            _fullSongIdLoadTask = Task.FromResult(ids);
+        }
+    }
+
+    protected async Task<List<Guid>> GetFullSongIdsAsync()
+    {
+        Task<List<Guid>> loadTask;
+        int generation;
+
+        lock (_fullSongIdsLock)
+        {
+            if (_isDisposed) return new List<Guid>();
+
+            generation = _fullSongIdGeneration;
+            var sortOrder = CurrentSortOrder;
+            loadTask = _fullSongIdLoadTask ??=
+                Task.Run(() => LoadAllSongIdsAsync(sortOrder, CancellationToken.None));
+        }
+
+        try
+        {
+            var ids = await loadTask.ConfigureAwait(false);
+            lock (_fullSongIdsLock)
+            {
+                if (_isDisposed || generation != _fullSongIdGeneration)
+                    return new List<Guid>();
+
+                if (ReferenceEquals(_fullSongIdLoadTask, loadTask))
+                    _fullSongIdList = ids;
+
+                return _fullSongIdList.ToList();
+            }
+        }
+        catch
+        {
+            lock (_fullSongIdsLock)
+            {
+                if (ReferenceEquals(_fullSongIdLoadTask, loadTask))
+                    _fullSongIdLoadTask = null;
+            }
+
+            throw;
+        }
     }
 
     /// <summary>
@@ -299,7 +368,8 @@ public abstract partial class SongListViewModelBase : PagedListViewModelBase<Son
                 await Task.Delay(100, token);
                 if (token.IsCancellationRequested) break;
 
-                var pagedResult = await LoadSongsPagedAsync(nextPageToLoad, SongsPerPage, CurrentSortOrder, token);
+                var pagedResult = await Task.Run(
+                    () => LoadSongsPagedAsync(nextPageToLoad, SongsPerPage, CurrentSortOrder, token), token);
                 if (pagedResult == null) break;
 
                 ProcessPagedResult(pagedResult, token, true);
@@ -338,7 +408,8 @@ public abstract partial class SongListViewModelBase : PagedListViewModelBase<Son
             _pagedLoadCts = new CancellationTokenSource();
             var token = _pagedLoadCts.Token;
 
-            var pagedResult = await LoadSongsPagedAsync(pageNumber, SongsPerPage, CurrentSortOrder, token);
+            var pagedResult = await Task.Run(
+                () => LoadSongsPagedAsync(pageNumber, SongsPerPage, CurrentSortOrder, token), token);
             ProcessPagedResult(pagedResult, token);
         }
         catch (Exception ex)
@@ -426,34 +497,16 @@ public abstract partial class SongListViewModelBase : PagedListViewModelBase<Son
     [RelayCommand(CanExecute = nameof(CanExecutePlayAllCommands))]
     private async Task PlayAllSongsAsync()
     {
-        // Always use the pre-fetched full ID list for memory efficiency and consistency.
-        List<Guid> ids;
-        _stateLock.EnterReadLock();
-        try
-        {
-            ids = _fullSongIdList.ToList();
-        }
-        finally
-        {
-            _stateLock.ExitReadLock();
-        }
+        var ids = await GetFullSongIdsAsync();
+        if (ids.Count == 0) return;
         await _playbackService.PlayAsync(ids, 0, null, GetPlaybackContext());
     }
 
     [RelayCommand(CanExecute = nameof(CanExecutePlayAllCommands))]
     private async Task ShuffleAndPlayAllSongsAsync()
     {
-        // Always use the pre-fetched full ID list for memory efficiency and consistency.
-        List<Guid> ids;
-        _stateLock.EnterReadLock();
-        try
-        {
-            ids = _fullSongIdList.ToList();
-        }
-        finally
-        {
-            _stateLock.ExitReadLock();
-        }
+        var ids = await GetFullSongIdsAsync();
+        if (ids.Count == 0) return;
         await _playbackService.PlayAsync(ids, 0, true, GetPlaybackContext());
     }
 
@@ -462,19 +515,8 @@ public abstract partial class SongListViewModelBase : PagedListViewModelBase<Son
     {
         if (song == null) return;
 
-        // Always use the pre-fetched full ID list to find the song's position.
-        int startIndex;
-        List<Guid> ids;
-        _stateLock.EnterReadLock();
-        try
-        {
-            startIndex = _fullSongIdList.IndexOf(song.Id);
-            ids = _fullSongIdList.ToList();
-        }
-        finally
-        {
-            _stateLock.ExitReadLock();
-        }
+        var ids = await GetFullSongIdsAsync();
+        var startIndex = ids.IndexOf(song.Id);
 
         if (startIndex == -1)
         {
@@ -579,16 +621,7 @@ public abstract partial class SongListViewModelBase : PagedListViewModelBase<Son
 
     private bool CanExecutePlayAllCommands()
     {
-        // Always use the pre-fetched full ID list for consistency.
-        _stateLock.EnterReadLock();
-        try
-        {
-            return !IsLoading && _fullSongIdList.Any();
-        }
-        finally
-        {
-            _stateLock.ExitReadLock();
-        }
+        return !IsLoading && Songs.Any();
     }
 
     private bool CanExecuteSelectedSongsCommands()
@@ -618,12 +651,13 @@ public abstract partial class SongListViewModelBase : PagedListViewModelBase<Son
         UpdateSelectionDependentCommands();
     }
 
-    protected virtual Task<List<Guid>> GetCurrentSelectionIdsAsync()
+    protected virtual async Task<List<Guid>> GetCurrentSelectionIdsAsync()
     {
+        var ids = await GetFullSongIdsAsync();
         _stateLock.EnterReadLock();
         try
         {
-            return Task.FromResult(SelectionState.GetSelectedIds(_fullSongIdList).ToList());
+            return SelectionState.GetSelectedIds(ids).ToList();
         }
         finally
         {
@@ -743,6 +777,7 @@ public abstract partial class SongListViewModelBase : PagedListViewModelBase<Son
     {
         base.ResetState();
         SelectionState.DeselectAll();
+        ClearFullSongIds();
         CancelInflightPageLoad();
         _pagedLoadCts?.Cancel();
         _pagedLoadCts?.Dispose();


### PR DESCRIPTION
Moves database-backed page loads off the UI thread, caches full playback ID lists on demand, and adds complete title-sort indexes.

Partially addresses #133. Metadata rescan reliability is handled in #149; first-run indexing must still read every file.