### PR TITLE
fix: make metadata rescans reliable

### DIFF
--- a/src/Nagi.Core/Services/Abstractions/IMetadataService.cs
+++ b/src/Nagi.Core/Services/Abstractions/IMetadataService.cs
@@ -16,6 +16,8 @@ public interface IMetadataService
     ///     for cover art files in the directory hierarchy up to (and including) this folder if no
     ///     embedded art is found.
     /// </param>
+    /// <param name="includeMediaAssets">Whether to process cover art and synchronized lyrics.</param>
     /// <returns>A <see cref="SongFileMetadata" /> object containing the extracted data and file properties.</returns>
-    Task<SongFileMetadata> ExtractMetadataAsync(string filePath, string? baseFolderPath = null);
+    Task<SongFileMetadata> ExtractMetadataAsync(string filePath, string? baseFolderPath = null,
+        bool includeMediaAssets = true);
 }

--- a/src/Nagi.Core/Services/Implementations/AtlMetadataService.cs
+++ b/src/Nagi.Core/Services/Implementations/AtlMetadataService.cs
@@ -43,7 +43,8 @@ public class AtlMetadataService : IMetadataService, IDisposable
     }
 
     /// <inheritdoc />
-    public async Task<SongFileMetadata> ExtractMetadataAsync(string filePath, string? baseFolderPath = null)
+    public async Task<SongFileMetadata> ExtractMetadataAsync(string filePath, string? baseFolderPath = null,
+        bool includeMediaAssets = true)
     {
         var metadata = new SongFileMetadata { FilePath = filePath };
 
@@ -54,11 +55,9 @@ public class AtlMetadataService : IMetadataService, IDisposable
             metadata.FileModifiedDate = fileInfo.LastWriteTimeUtc;
             metadata.Title = ArtistNameHelper.NormalizeStringCore(_fileSystem.GetFileNameWithoutExtension(filePath)) ?? _fileSystem.GetFileNameWithoutExtension(filePath);
 
-            // Use a timeout wrapper for ATL operations to prevent indefinite hangs
+            // ATL parsing is synchronous, so enforce the timeout while awaiting it.
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-
-            // Track does not implement IDisposable, using Task.Run for async-like behavior
-            var track = await Task.Run(() => new Track(filePath), cts.Token).ConfigureAwait(false);
+            var track = await Task.Run(() => new Track(filePath)).WaitAsync(cts.Token).ConfigureAwait(false);
 
             // Check if the file is valid - ATL is lenient so we need multiple checks
             // Check 1: AudioFormat.Readable flag
@@ -78,31 +77,35 @@ public class AtlMetadataService : IMetadataService, IDisposable
             var genreSplitCharacters = await GetCachedGenreSplitCharactersAsync().ConfigureAwait(false);
             PopulateMetadataFromTrack(metadata, track, splitCharacters, genreSplitCharacters);
 
-            // Get cached or extract new synchronized lyrics (after parsing track so we have artist/title).
-            using var lrcCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-            try
+            if (includeMediaAssets)
             {
-                metadata.LrcFilePath = await GetLrcPathAsync(filePath, fileInfo.LastWriteTimeUtc, metadata.Artists?.FirstOrDefault() ?? Artist.UnknownArtistName, metadata.Album, metadata.Title, track)
+                // Get cached or extract new synchronized lyrics.
+                using var lrcCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+                try
+                {
+                    metadata.LrcFilePath = await GetLrcPathAsync(filePath, fileInfo.LastWriteTimeUtc,
+                            metadata.Artists?.FirstOrDefault() ?? Artist.UnknownArtistName, metadata.Album,
+                            metadata.Title, track)
+                        .WaitAsync(lrcCts.Token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    _logger.LogWarning("LRC extraction timed out for file: {FilePath}", filePath);
+                }
 
-                    .WaitAsync(lrcCts.Token).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException)
-            {
-                _logger.LogWarning("LRC extraction timed out for file: {FilePath}", filePath);
-            }
+                if (string.IsNullOrWhiteSpace(metadata.LrcFilePath))
+                    metadata.LrcFilePath = FindLrcFilePath(filePath);
 
-            // As a fallback, look for an external .lrc file if no embedded lyrics were found.
-            if (string.IsNullOrWhiteSpace(metadata.LrcFilePath)) metadata.LrcFilePath = FindLrcFilePath(filePath);
-
-            // Process album art with timeout protection
-            using var albumArtCts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
-            try
-            {
-                await ProcessAlbumArtAsync(metadata, track, baseFolderPath).WaitAsync(albumArtCts.Token).ConfigureAwait(false);
-            }
-            catch (OperationCanceledException)
-            {
-                _logger.LogWarning("Album art extraction timed out for file: {FilePath}", filePath);
+                using var albumArtCts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+                try
+                {
+                    await ProcessAlbumArtAsync(metadata, track, baseFolderPath).WaitAsync(albumArtCts.Token)
+                        .ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    _logger.LogWarning("Album art extraction timed out for file: {FilePath}", filePath);
+                }
             }
         }
         catch (OperationCanceledException)

--- a/src/Nagi.Core/Services/Implementations/LibraryService.cs
+++ b/src/Nagi.Core/Services/Implementations/LibraryService.cs
@@ -672,7 +672,8 @@ public class LibraryService : ILibraryService, ILibraryReader, IDisposable
     private async Task<bool> RescanFolderForMusicAsync(Guid folderId, bool forceFullScan, bool allowFolderRemovalOnMissing,
         IProgress<ScanProgress>? progress = null,
         CancellationToken cancellationToken = default,
-        bool registerAsActiveScan = true)
+        bool registerAsActiveScan = true,
+        bool throwOnFailure = false)
     {
         using var operationCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _shutdownCts.Token);
         var operationToken = operationCts.Token;
@@ -703,6 +704,8 @@ public class LibraryService : ILibraryService, ILibraryReader, IDisposable
                 {
                     _logger.LogWarning("Cannot rescan folder: Folder with ID {FolderId} not found.", folderId);
                     progress?.Report(new ScanProgress { StatusText = string.Format(Resources.Strings.Format_NotFound, Resources.Strings.Label_Folder), Percentage = 100 });
+                    if (throwOnFailure)
+                        throw new InvalidOperationException($"Folder {folderId} was not found.");
                     return false;
                 }
 
@@ -727,6 +730,8 @@ public class LibraryService : ILibraryService, ILibraryReader, IDisposable
                                 folder.Path, folder.Id);
                             progress?.Report(new ScanProgress
                             { StatusText = Resources.Strings.Status_ScanFailed, Percentage = 100 });
+                            if (throwOnFailure)
+                                throw new DirectoryNotFoundException($"Library folder was not found: {folder.Path}");
                             return false;
                         }
 
@@ -881,7 +886,8 @@ public class LibraryService : ILibraryService, ILibraryReader, IDisposable
                     // Use streaming extraction for better memory efficiency
                     var filePathsBeingUpdated = filesToUpdate.ToHashSet(StringComparer.OrdinalIgnoreCase);
                     var (newSongsFound, discoveredDirs) = await ExtractAndSaveMetadataStreamingAsync(
-                        folderId, filesToProcess, folder.Path, filePathsBeingUpdated, progress, operationToken).ConfigureAwait(false);
+                        folderId, filesToProcess, folder.Path, filePathsBeingUpdated, progress, operationToken,
+                        skipMediaAssetsForUpdates: forceFullScan).ConfigureAwait(false);
 
                     operationToken.ThrowIfCancellationRequested();
 
@@ -934,6 +940,8 @@ public class LibraryService : ILibraryService, ILibraryReader, IDisposable
                     _logger.LogCritical(ex, "FATAL: Rescan for folder ID {FolderId} failed.", folderId);
                     progress?.Report(new ScanProgress
                     { StatusText = Resources.Strings.Status_ScanFailed, Percentage = 100 });
+                    if (throwOnFailure)
+                        throw;
                     return false;
                 }
             }, operationToken);
@@ -1051,12 +1059,18 @@ public class LibraryService : ILibraryService, ILibraryReader, IDisposable
     public Task<bool> ForceRescanMetadataAsync(IProgress<ScanProgress>? progress = null,
         CancellationToken cancellationToken = default)
     {
-        return RefreshAllFoldersAsync(true, progress, cancellationToken);
+        return RefreshAllFoldersCoreAsync(true, true, progress, cancellationToken);
     }
 
     /// <inheritdoc />
-    public async Task<bool> RefreshAllFoldersAsync(bool forceFullScan, IProgress<ScanProgress>? progress = null,
+    public Task<bool> RefreshAllFoldersAsync(bool forceFullScan, IProgress<ScanProgress>? progress = null,
         CancellationToken cancellationToken = default)
+    {
+        return RefreshAllFoldersCoreAsync(forceFullScan, false, progress, cancellationToken);
+    }
+
+    private async Task<bool> RefreshAllFoldersCoreAsync(bool forceFullScan, bool throwOnFailure,
+        IProgress<ScanProgress>? progress, CancellationToken cancellationToken)
     {
         CancelActiveScan(forceFullScan ? "forced library refresh" : "library refresh");
         using var operationCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _shutdownCts.Token);
@@ -1115,8 +1129,10 @@ public class LibraryService : ILibraryService, ILibraryReader, IDisposable
                     // (e.g., NAS not mounted yet, external drive unplugged). Only explicit user
                     // rescan (which calls the public overload) may trigger folder removal.
                     var changes = await RescanFolderForMusicAsync(folder.Id, forceFullScan,
-                            allowFolderRemovalOnMissing: false, newProgress, operationToken, registerAsActiveScan: false)
+                            allowFolderRemovalOnMissing: false, newProgress, operationToken, registerAsActiveScan: false,
+                            throwOnFailure: throwOnFailure)
                         .ConfigureAwait(false);
+                    operationToken.ThrowIfCancellationRequested();
                     if (changes) anyChangesMade = true;
 
                     foldersProcessed++;
@@ -1150,6 +1166,8 @@ public class LibraryService : ILibraryService, ILibraryReader, IDisposable
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to refresh all library folders.");
+            if (throwOnFailure)
+                throw;
             return false;
         }
         finally
@@ -3984,7 +4002,8 @@ public class LibraryService : ILibraryService, ILibraryReader, IDisposable
         string baseFolderPath,
         IReadOnlySet<string> filePathsBeingUpdated,
         IProgress<ScanProgress>? progress,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        bool skipMediaAssetsForUpdates = false)
     {
         const int channelCapacity = 100; // ~2 batches of buffer for backpressure
         var channel = Channel.CreateBounded<SongFileMetadata>(new BoundedChannelOptions(channelCapacity)
@@ -3993,6 +4012,8 @@ public class LibraryService : ILibraryService, ILibraryReader, IDisposable
             SingleReader = true,
             SingleWriter = false
         });
+        using var pipelineCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var pipelineToken = pipelineCts.Token;
 
         var totalFiles = filesToProcess.Count;
         var processedCount = 0;
@@ -4077,13 +4098,17 @@ public class LibraryService : ILibraryService, ILibraryReader, IDisposable
                     new ParallelOptions
                     {
                         MaxDegreeOfParallelism = degreeOfParallelism,
-                        CancellationToken = cancellationToken
+                        CancellationToken = pipelineToken
                     },
                     async (filePath, ct) =>
                     {
                         try
                         {
-                            var metadata = await _metadataService.ExtractMetadataAsync(filePath, baseFolderPath).ConfigureAwait(false);
+                            var includeMediaAssets = !skipMediaAssetsForUpdates || !filePathsBeingUpdated.Contains(filePath);
+                            var extractionTask = includeMediaAssets
+                                ? _metadataService.ExtractMetadataAsync(filePath, baseFolderPath)
+                                : _metadataService.ExtractMetadataAsync(filePath, baseFolderPath, false);
+                            var metadata = await extractionTask.WaitAsync(ct).ConfigureAwait(false);
 
                             // Retry once for transient failure classes. UnsupportedFormat / CorruptFile
                             // are permanent — no point retrying. Timeouts and file-access errors are
@@ -4092,7 +4117,10 @@ public class LibraryService : ILibraryService, ILibraryReader, IDisposable
                                 (metadata.ErrorMessage == "ExtractionTimeout" || metadata.ErrorMessage == "FileAccessError"))
                             {
                                 try { await Task.Delay(500, ct).ConfigureAwait(false); } catch (OperationCanceledException) { throw; }
-                                metadata = await _metadataService.ExtractMetadataAsync(filePath, baseFolderPath).ConfigureAwait(false);
+                                extractionTask = includeMediaAssets
+                                    ? _metadataService.ExtractMetadataAsync(filePath, baseFolderPath)
+                                    : _metadataService.ExtractMetadataAsync(filePath, baseFolderPath, false);
+                                metadata = await extractionTask.WaitAsync(ct).ConfigureAwait(false);
                             }
 
                             if (!metadata.ExtractionFailed)
@@ -4133,7 +4161,7 @@ public class LibraryService : ILibraryService, ILibraryReader, IDisposable
                 channel.Writer.TryComplete(ex);
                 throw;
             }
-        }, cancellationToken);
+        }, pipelineToken);
 
         // Single explicit transaction wrapping all batches — reduces SQLite fsyncs from N to 1.
         // Each SaveChangesAsync writes SQL to the WAL without committing; CommitAsync() does a single fsync.
@@ -4148,7 +4176,7 @@ public class LibraryService : ILibraryService, ILibraryReader, IDisposable
                 var batch = new List<SongFileMetadata>(500);
                 var batchNumber = 0;
 
-                await foreach (var metadata in channel.Reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
+                await foreach (var metadata in channel.Reader.ReadAllAsync(pipelineToken).ConfigureAwait(false))
                 {
                     batch.Add(metadata);
                     var dir = _fileSystem.GetDirectoryName(metadata.FilePath);
@@ -4165,7 +4193,9 @@ public class LibraryService : ILibraryService, ILibraryReader, IDisposable
                         });
 
                         _logger.LogInformation("Consumer processing batch {BatchNumber}...", batchNumber);
-                        var saved = await ProcessSingleBatchAsync(folderId, batch.ToArray(), batchContext, artistIdCache, albumIdCache, genreIdCache, filePathsBeingUpdated, cancellationToken).ConfigureAwait(false);
+                        var saved = await ProcessSingleBatchAsync(folderId, batch.ToArray(), batchContext, artistIdCache,
+                            albumIdCache, genreIdCache, filePathsBeingUpdated, skipMediaAssetsForUpdates,
+                            pipelineToken).ConfigureAwait(false);
                         _logger.LogInformation("Consumer finished batch {BatchNumber}. Saved {Count} items.", batchNumber, saved);
                         totalSaved += saved;
                         batch.Clear();
@@ -4184,16 +4214,20 @@ public class LibraryService : ILibraryService, ILibraryReader, IDisposable
                         NewSongsFound = extractedCount
                     });
 
-                    var saved = await ProcessSingleBatchAsync(folderId, batch.ToArray(), batchContext, artistIdCache, albumIdCache, genreIdCache, filePathsBeingUpdated, cancellationToken).ConfigureAwait(false);
+                    var saved = await ProcessSingleBatchAsync(folderId, batch.ToArray(), batchContext, artistIdCache,
+                        albumIdCache, genreIdCache, filePathsBeingUpdated, skipMediaAssetsForUpdates,
+                        pipelineToken).ConfigureAwait(false);
                     totalSaved += saved;
                 }
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
+                pipelineCts.Cancel();
+                channel.Writer.TryComplete(ex);
                 _logger.LogError(ex, "Consumer failed in streaming metadata extraction for folder {FolderId}", folderId);
                 throw;
             }
-        }, cancellationToken);
+        }, pipelineToken);
 
         await Task.WhenAll(producerTask, consumerTask).ConfigureAwait(false);
         await scanTransaction.CommitAsync(cancellationToken).ConfigureAwait(false);
@@ -4223,6 +4257,7 @@ public class LibraryService : ILibraryService, ILibraryReader, IDisposable
         ConcurrentDictionary<string, Guid> albumIdCache,
         ConcurrentDictionary<string, Guid> genreIdCache,
         IReadOnlySet<string> filePathsBeingUpdated,
+        bool preserveMediaAssetsForUpdates,
         CancellationToken cancellationToken)
     {
         if (metadataList.Length == 0)
@@ -4283,7 +4318,8 @@ public class LibraryService : ILibraryService, ILibraryReader, IDisposable
         foreach (var metadata in metadataList)
         {
             existingSongs.TryGetValue(metadata.FilePath, out var existingSong);
-            AddSongWithDetailsCached(context, folderId, metadata, artistLookup, albumLookup, genreLookup, existingSong);
+            AddSongWithDetailsCached(context, folderId, metadata, artistLookup, albumLookup, genreLookup, existingSong,
+                preserveMediaAssetsForUpdates && existingSong != null);
         }
 
         _logger.LogInformation("Saving changes for batch...");
@@ -4417,13 +4453,19 @@ public class LibraryService : ILibraryService, ILibraryReader, IDisposable
                 uncachedNames.Add(name);
         }
 
-        // Step 2: Attach stub entities for cached genres — we already know Id + Name so no DB round-trip needed.
-        // context.Attach marks them as Unchanged; EF uses the Id for FK references without hitting the DB.
+        var trackedGenres = context.ChangeTracker.Entries<Genre>()
+            .Select(entry => entry.Entity)
+            .ToDictionary(genre => genre.Id);
+
+        // Reuse genres loaded with existing songs before attaching stubs.
         foreach (var (id, name) in cachedEntries)
         {
-            var stub = new Genre { Id = id, Name = name };
-            context.Attach(stub);
-            genreLookup[name] = stub;
+            if (!trackedGenres.TryGetValue(id, out var genre))
+            {
+                genre = new Genre { Id = id, Name = name };
+                context.Attach(genre);
+            }
+            genreLookup[name] = genre;
         }
 
         // Step 3: Create new genres directly — no DB double-check needed (same rationale as artists).
@@ -4601,7 +4643,8 @@ public class LibraryService : ILibraryService, ILibraryReader, IDisposable
         Dictionary<string, Artist> artistLookup,
         Dictionary<string, Album> albumLookup,
         Dictionary<string, Genre> genreLookup,
-        Song? existingSong = null)
+        Song? existingSong = null,
+        bool preserveMediaAssets = false)
     {
         // Filter and validate artist names with consistent normalization
         var trackArtistNames = metadata.Artists.Select(ArtistNameHelper.Normalize).ToList();
@@ -4649,9 +4692,13 @@ public class LibraryService : ILibraryService, ILibraryReader, IDisposable
         song.DirectoryPath = directoryPath;
         song.Title = metadata.Title;
         song.DurationTicks = metadata.Duration.Ticks;
-        song.AlbumArtUriFromTrack = metadata.CoverArtUri;
-        song.LightSwatchId = metadata.LightSwatchId;
-        song.DarkSwatchId = metadata.DarkSwatchId;
+        if (!preserveMediaAssets)
+        {
+            song.AlbumArtUriFromTrack = metadata.CoverArtUri;
+            song.LightSwatchId = metadata.LightSwatchId;
+            song.DarkSwatchId = metadata.DarkSwatchId;
+            song.LrcFilePath = metadata.LrcFilePath;
+        }
         song.Year = metadata.Year;
         song.TrackNumber = metadata.TrackNumber;
         song.TrackCount = metadata.TrackCount;
@@ -4666,7 +4713,6 @@ public class LibraryService : ILibraryService, ILibraryReader, IDisposable
         song.Composer = metadata.Composer;
         song.Bpm = metadata.Bpm;
         song.Lyrics = metadata.Lyrics;
-        song.LrcFilePath = metadata.LrcFilePath;
 
         // Use FK assignment for existing (Unchanged) albums; navigation property for new (Added) albums.
         // Setting song.Album = album for new albums lets EF Core wire up the relationship graph correctly,

--- a/src/Nagi.WinUI/MainPage.xaml
+++ b/src/Nagi.WinUI/MainPage.xaml
@@ -608,6 +608,11 @@
                     TextAlignment="Center"
                     TextTrimming="CharacterEllipsis"
                     TextWrapping="NoWrap" />
+                <Button
+                    HorizontalAlignment="Center"
+                    Command="{x:Bind ViewModel.CancelGlobalOperationCommand}"
+                    Content="{x:Bind resources:Strings.Generic_Cancel, Mode=OneTime}"
+                    Visibility="{x:Bind ViewModel.IsGlobalOperationCancellable, Converter={StaticResource BooleanToVisibilityConverter}, Mode=OneWay}" />
             </StackPanel>
         </Grid>
 

--- a/src/Nagi.WinUI/ViewModels/PlayerViewModel.cs
+++ b/src/Nagi.WinUI/ViewModels/PlayerViewModel.cs
@@ -63,6 +63,7 @@ public partial class PlayerViewModel : ObservableObject
     // Navigation re-entry guards
     private bool _isNavigatingToArtist;
     private bool _isNavigatingToAlbum;
+    private Action? _cancelGlobalOperation;
 
     public PlayerViewModel(IMusicPlaybackService playbackService, INavigationService navigationService,
         IMusicNavigationService musicNavigationService,
@@ -138,6 +139,9 @@ public partial class PlayerViewModel : ObservableObject
     [ObservableProperty] public partial string GlobalOperationStatusMessage { get; set; }
     [ObservableProperty] public partial double GlobalOperationProgressValue { get; set; }
     [ObservableProperty] public partial bool IsGlobalOperationIndeterminate { get; set; }
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(CancelGlobalOperationCommand))]
+    public partial bool IsGlobalOperationCancellable { get; set; }
     [ObservableProperty] public partial bool IsQueueViewVisible { get; set; }
 
     [ObservableProperty] public partial bool IsVolumeControlVisible { get; set; }
@@ -157,6 +161,22 @@ public partial class PlayerViewModel : ObservableObject
         RepeatMode.RepeatOne => RepeatOneIconGlyph,
         _ => RepeatOffIconGlyph
     };
+
+    public void SetGlobalOperationCancellation(Action? cancel)
+    {
+        Interlocked.Exchange(ref _cancelGlobalOperation, cancel);
+        IsGlobalOperationCancellable = cancel != null;
+    }
+
+    private bool CanCancelGlobalOperation() => IsGlobalOperationCancellable;
+
+    [RelayCommand(CanExecute = nameof(CanCancelGlobalOperation))]
+    private void CancelGlobalOperation()
+    {
+        var cancel = Interlocked.Exchange(ref _cancelGlobalOperation, null);
+        IsGlobalOperationCancellable = false;
+        cancel?.Invoke();
+    }
 
     public string RepeatButtonToolTip => CurrentRepeatMode switch
     {

--- a/src/Nagi.WinUI/ViewModels/SettingsViewModel.cs
+++ b/src/Nagi.WinUI/ViewModels/SettingsViewModel.cs
@@ -129,6 +129,7 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
     private bool _isLoaded;
     private CancellationTokenSource? _preampDebounceCts;
     private CancellationTokenSource? _replayGainScanCts;
+    private CancellationTokenSource? _metadataRescanCts;
     private CancellationTokenSource? _playerButtonSaveCts;
     private CancellationTokenSource? _navigationItemSaveCts;
     private CancellationTokenSource? _lyricsProviderSaveCts;
@@ -431,6 +432,8 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
         _preampDebounceCts?.Dispose();
         _replayGainScanCts?.Cancel();
         _replayGainScanCts?.Dispose();
+        _metadataRescanCts?.Cancel();
+        _metadataRescanCts?.Dispose();
         _playerButtonSaveCts?.Cancel();
         _playerButtonSaveCts?.Dispose();
         _navigationItemSaveCts?.Cancel();
@@ -1304,12 +1307,20 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
 
         if (!confirmed) return;
 
+        _metadataRescanCts?.Cancel();
+        _metadataRescanCts?.Dispose();
+        var rescanCts = new CancellationTokenSource();
+        _metadataRescanCts = rescanCts;
+
         _playerViewModel.IsGlobalOperationInProgress = true;
         _playerViewModel.GlobalOperationStatusMessage = Nagi.WinUI.Resources.Strings.Settings_Status_Rescan_Preparing;
         _playerViewModel.IsGlobalOperationIndeterminate = true;
+        _playerViewModel.SetGlobalOperationCancellation(rescanCts.Cancel);
 
         try
         {
+            await SaveMetadataSplitSettingsAsync();
+
             var progress = new Progress<ScanProgress>(p =>
             {
                 _playerViewModel.GlobalOperationStatusMessage = p.StatusText;
@@ -1317,9 +1328,14 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
                 _playerViewModel.GlobalOperationProgressValue = p.Percentage;
             });
 
-            await _libraryScanner.ForceRescanMetadataAsync(progress);
+            await _libraryScanner.ForceRescanMetadataAsync(progress, rescanCts.Token);
+            rescanCts.Token.ThrowIfCancellationRequested();
 
             await _uiService.ShowMessageDialogAsync(Nagi.WinUI.Resources.Strings.Settings_Dialog_RescanComplete_Title, Nagi.WinUI.Resources.Strings.Settings_Dialog_RescanComplete_Content);
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogInformation("Metadata rescan cancelled.");
         }
         catch (Exception ex)
         {
@@ -1328,9 +1344,27 @@ public partial class SettingsViewModel : ObservableObject, IDisposable
         }
         finally
         {
+            _playerViewModel.SetGlobalOperationCancellation(null);
             _playerViewModel.IsGlobalOperationInProgress = false;
             _playerViewModel.IsGlobalOperationIndeterminate = false;
+            if (ReferenceEquals(_metadataRescanCts, rescanCts))
+                _metadataRescanCts = null;
+            rescanCts.Dispose();
         }
+    }
+
+    private async Task SaveMetadataSplitSettingsAsync()
+    {
+        _artistSplitSaveCts?.Cancel();
+        _artistSplitSaveCts?.Dispose();
+        _artistSplitSaveCts = null;
+        _genreSplitSaveCts?.Cancel();
+        _genreSplitSaveCts?.Dispose();
+        _genreSplitSaveCts = null;
+
+        await Task.WhenAll(
+            _settingsService.SetArtistSplitCharactersAsync(ArtistSplitCharacters),
+            _settingsService.SetGenreSplitCharactersAsync(GenreSplitCharacters));
     }
 
     private async Task SavePlayerButtonSettingsAsync(List<PlayerButtonSetting> settings)

--- a/tests/Nagi.Core.Tests/LibraryServiceBugTests.cs
+++ b/tests/Nagi.Core.Tests/LibraryServiceBugTests.cs
@@ -113,6 +113,37 @@ public class LibraryServiceBugTests : IDisposable
     }
 
     [Fact]
+    public async Task RescanFolderForMusicAsync_WhenConsumerFails_DoesNotDeadlock()
+    {
+        var folder = new Folder { Id = Guid.NewGuid(), Path = "C:\\Music\\BrokenScan", Name = "BrokenScan" };
+        await using (var context = _dbHelper.ContextFactory.CreateDbContext())
+        {
+            context.Folders.Add(folder);
+            await context.SaveChangesAsync();
+        }
+
+        var songFiles = Enumerable.Range(1, 200)
+            .Select(i => ($"C:\\Music\\BrokenScan\\song{i}.mp3", DateTime.UtcNow))
+            .ToList();
+        _fileSystem.DirectoryExists(folder.Path).Returns(true);
+        _fileSystem.EnumerateFilesWithLastWriteTime(folder.Path, "*.*", SearchOption.AllDirectories)
+            .Returns(songFiles);
+        _fileSystem.GetExtension(Arg.Any<string>()).Returns(".mp3");
+        _metadataService.ExtractMetadataAsync(Arg.Any<string>(), folder.Path)
+            .Returns(call => new SongFileMetadata
+            {
+                FilePath = call.ArgAt<string>(0),
+                Title = "Song",
+                Artists = null!
+            });
+
+        var result = await _libraryService.RescanFolderForMusicAsync(folder.Id)
+            .WaitAsync(TimeSpan.FromSeconds(5));
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
     public async Task RemoveFolderAsync_WhenBackgroundRefreshIsScanning_CancelsScanAndRemovesFolder()
     {
         var folder = new Folder { Id = Guid.NewGuid(), Path = "C:\\Music\\BusyScan", Name = "BusyScan" };
@@ -147,10 +178,9 @@ public class LibraryServiceBugTests : IDisposable
         await extractionStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
         var removeTask = _libraryService.RemoveFolderAsync(folder.Id);
-        await Task.Delay(100);
-        allowExtractionToFinish.TrySetResult();
         var removed = await removeTask.WaitAsync(TimeSpan.FromSeconds(5));
         var refreshResult = await refreshTask.WaitAsync(TimeSpan.FromSeconds(5));
+        allowExtractionToFinish.TrySetResult();
 
         removed.Should().BeTrue();
         refreshResult.Should().BeFalse("the in-flight refresh was cancelled by folder removal");
@@ -326,6 +356,86 @@ public class LibraryServiceBugTests : IDisposable
             collaboratorFromDb.Should().NotBeNull();
         }
     }
+
+    [Fact]
+    public async Task ForceRescanMetadataAsync_PreservesMediaAssetsWhileUpdatingGenres()
+    {
+        var folder = new Folder { Id = Guid.NewGuid(), Path = "C:\\Music\\Genres", Name = "Genres" };
+        var artist = new Artist { Name = "Artist" };
+        var existingGenre = new Genre { Name = "Electronic" };
+        var oldGenre = new Genre { Name = "Electronic\\Techno" };
+        var filePath = "C:\\Music\\Genres\\song.mp3";
+        var modified = DateTime.UtcNow.AddDays(-1);
+        var song = new Song
+        {
+            Title = "Song",
+            FilePath = filePath,
+            DirectoryPath = folder.Path,
+            FolderId = folder.Id,
+            FileModifiedDate = modified,
+            AlbumArtUriFromTrack = "cached-cover.jpg",
+            LightSwatchId = "light",
+            DarkSwatchId = "dark",
+            LrcFilePath = "cached-lyrics.lrc"
+        };
+        song.SongArtists.Add(new SongArtist { Artist = artist, Order = 0 });
+        song.Genres.Add(existingGenre);
+        song.Genres.Add(oldGenre);
+        song.SyncDenormalizedFields();
+
+        await using (var context = _dbHelper.ContextFactory.CreateDbContext())
+        {
+            context.Folders.Add(folder);
+            context.Songs.Add(song);
+            await context.SaveChangesAsync();
+        }
+
+        _fileSystem.DirectoryExists(folder.Path).Returns(true);
+        _fileSystem.EnumerateFilesWithLastWriteTime(folder.Path, "*.*", SearchOption.AllDirectories)
+            .Returns(new[] { (filePath, modified) });
+        _fileSystem.GetExtension(filePath).Returns(".mp3");
+        _metadataService.ExtractMetadataAsync(filePath, folder.Path, false)
+            .Returns(new SongFileMetadata
+            {
+                FilePath = filePath,
+                FileModifiedDate = modified,
+                Title = "Song",
+                Artists = ["Artist"],
+                AlbumArtists = ["Artist"],
+                Genres = ["Electronic", "Techno"]
+            });
+
+        var result = await _libraryService.ForceRescanMetadataAsync().WaitAsync(TimeSpan.FromSeconds(5));
+
+        result.Should().BeTrue();
+        await _metadataService.Received(1).ExtractMetadataAsync(filePath, folder.Path, false);
+        await using var assertContext = _dbHelper.ContextFactory.CreateDbContext();
+        var updated = await assertContext.Songs.Include(s => s.Genres).SingleAsync();
+        updated.Genres.Select(g => g.Name).Should().BeEquivalentTo("Electronic", "Techno");
+        updated.AlbumArtUriFromTrack.Should().Be("cached-cover.jpg");
+        updated.LightSwatchId.Should().Be("light");
+        updated.DarkSwatchId.Should().Be("dark");
+        updated.LrcFilePath.Should().Be("cached-lyrics.lrc");
+    }
+
+    [Fact]
+    public async Task ForceRescanMetadataAsync_WhenFolderIsUnavailable_ReportsFailure()
+    {
+        var folder = new Folder { Id = Guid.NewGuid(), Path = "Z:\\Offline", Name = "Offline" };
+        await using (var context = _dbHelper.ContextFactory.CreateDbContext())
+        {
+            context.Folders.Add(folder);
+            await context.SaveChangesAsync();
+        }
+        _fileSystem.DirectoryExists(folder.Path).Returns(false);
+
+        var act = () => _libraryService.ForceRescanMetadataAsync();
+
+        await act.Should().ThrowAsync<DirectoryNotFoundException>();
+        await using var assertContext = _dbHelper.ContextFactory.CreateDbContext();
+        (await assertContext.Folders.CountAsync()).Should().Be(1);
+    }
+
     [Fact]
     public async Task RescanFolderForMusicAsync_WithUntrimmedArtistNames_DoesNotThrow()
     {

--- a/tests/Nagi.Core.Tests/LibraryServiceEventTests.cs
+++ b/tests/Nagi.Core.Tests/LibraryServiceEventTests.cs
@@ -194,4 +194,43 @@ public class LibraryServiceEventTests : IDisposable
         eventArgs!.ChangeType.Should().Be(LibraryChangeType.LibraryRescanned);
         eventArgs.FolderId.Should().BeNull();
     }
+
+    [Fact]
+    public async Task ForceRescanMetadataAsync_CancelledInFinalFolder_DoesNotFireLibraryRescanned()
+    {
+        var firstFolder = new Folder { Id = Guid.NewGuid(), Path = "C:\\Music\\A", Name = "A" };
+        var finalFolder = new Folder { Id = Guid.NewGuid(), Path = "C:\\Music\\B", Name = "B" };
+        await using (var context = _dbHelper.ContextFactory.CreateDbContext())
+        {
+            context.Folders.AddRange(firstFolder, finalFolder);
+            await context.SaveChangesAsync();
+        }
+
+        var firstFile = "C:\\Music\\A\\first.mp3";
+        var finalFile = "C:\\Music\\B\\final.mp3";
+        _fileSystem.DirectoryExists(Arg.Any<string>()).Returns(true);
+        _fileSystem.EnumerateFilesWithLastWriteTime(firstFolder.Path, "*.*", SearchOption.AllDirectories)
+            .Returns(new[] { (firstFile, DateTime.UtcNow) });
+        _fileSystem.EnumerateFilesWithLastWriteTime(finalFolder.Path, "*.*", SearchOption.AllDirectories)
+            .Returns(new[] { (finalFile, DateTime.UtcNow) });
+        _fileSystem.GetExtension(Arg.Any<string>()).Returns(".mp3");
+
+        using var cts = new CancellationTokenSource();
+        _metadataService.ExtractMetadataAsync(firstFile, firstFolder.Path)
+            .Returns(new SongFileMetadata { FilePath = firstFile, Title = "First" });
+        _metadataService.ExtractMetadataAsync(finalFile, finalFolder.Path)
+            .Returns(_ =>
+            {
+                cts.Cancel();
+                return Task.FromResult(new SongFileMetadata { FilePath = finalFile, Title = "Final" });
+            });
+
+        var changeTypes = new List<LibraryChangeType>();
+        _libraryService.LibraryContentChanged += (_, e) => changeTypes.Add(e.ChangeType);
+
+        var result = await _libraryService.ForceRescanMetadataAsync(cancellationToken: cts.Token);
+
+        result.Should().BeFalse();
+        changeTypes.Should().NotContain(LibraryChangeType.LibraryRescanned);
+    }
 }


### PR DESCRIPTION
Flushes pending split settings before rescanning, skips redundant media-asset work, and makes ATL and pipeline cancellation effective. Also fixes unchanged genres causing the batch writer to fault and hang, and surfaces unavailable-folder failures.

Partially addresses #133. First-run indexing must still read every file.