### PR TITLE
chore: update dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: FedericoCarboni/setup-ffmpeg@v3.1
 
       - name: Run tests
-        run: dotnet test tests/Nagi.Core.Tests/Nagi.Core.Tests.csproj -c Release --logger "trx;logfilename=test-results.trx"
+        run: dotnet test --project tests/Nagi.Core.Tests/Nagi.Core.Tests.csproj -c Release --report-xunit-trx --report-xunit-trx-filename test-results.trx
 
       - name: Upload test results
         if: failure()

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,7 @@
         <NetVersion>10.0</NetVersion>
         <WindowsSdkVersion>10.0.26100</WindowsSdkVersion>
         <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
-        <WindowsTargetPlatformMaxTestedVersion>10.0.19041.0</WindowsTargetPlatformMaxTestedVersion>
+        <WindowsTargetPlatformMaxTestedVersion>10.0.26100.0</WindowsTargetPlatformMaxTestedVersion>
         <AppxPackageVersion>2.0.2.0</AppxPackageVersion>
     </PropertyGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,31 +9,31 @@
     <PackageVersion Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.3.260402-preview2" />
     <PackageVersion Include="CommunityToolkit.WinUI.Media" Version="8.3.260402-preview2" />
     <!-- WinAppSDK -->
-    <PackageVersion Include="Microsoft.WindowsAppSDK.Runtime" Version="2.2.0" />
-    <PackageVersion Include="Microsoft.WindowsAppSDK.WinUI" Version="2.2.1" />
-    <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.2270" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK.Runtime" Version="2.4.0" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK.WinUI" Version="2.3.6" />
+    <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.28000.2705" />
     <PackageVersion Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="3.0.1" />
     <!-- UI Controls -->
     <PackageVersion Include="H.NotifyIcon.WinUI" Version="2.5.0-dev.2" />
     <PackageVersion Include="ImageEx.WinUI" Version="5.0.0" />
     <PackageVersion Include="MessageFormat" Version="8.0.0" />
     <!-- Entity Framework Core -->
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.11" />
     <!-- Microsoft Extensions -->
-    <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.FileExtensions" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.11" />
     <!-- Resilience (rate limiting, retry, circuit breaker) -->
     <PackageVersion Include="Polly" Version="8.7.0" />
     <PackageVersion Include="Polly.RateLimiting" Version="8.7.0" />
     <!-- Media Playback -->
     <PackageVersion Include="LibVLCSharp" Version="4.0.0-alpha-20260828-10280" />
-    <PackageVersion Include="VideoLAN.LibVLC.Windows" Version="4.0.0-alpha-20260829" />
+    <PackageVersion Include="VideoLAN.LibVLC.Windows" Version="4.0.0-alpha-20260830" />
     <!-- Serilog -->
     <PackageVersion Include="Serilog.Enrichers.Thread" Version="4.0.0" />
     <PackageVersion Include="Serilog.Extensions.Logging" Version="10.0.0" />
@@ -42,31 +42,31 @@
     <PackageVersion Include="Serilog.Sinks.File" Version="8.0.0-nblumhardt-02322" />
     <!-- Audio & Metadata -->
     <PackageVersion Include="ModernLrc" Version="1.2.0" />
-    <PackageVersion Include="z440.atl.core" Version="7.15.3" />
+    <PackageVersion Include="z440.atl.core" Version="7.16.0" />
     <!-- Image Processing -->
     <PackageVersion Include="MaterialColorUtilities" Version="0.3.0" />
-    <PackageVersion Include="SixLabors.ImageSharp" Version="4.0.0" />
-    <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
+    <PackageVersion Include="SixLabors.ImageSharp" Version="4.1.1" />
+    <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.5" />
     <!-- Presence -->
     <PackageVersion Include="DiscordRichPresence" Version="1.6.1.70" />
     <!-- Azure Functions -->
-    <PackageVersion Include="Azure.Identity" Version="1.17.2" />
+    <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <!-- 3.x removes telemetry interfaces still required by Functions.Worker.ApplicationInsights 2.x. -->
     <PackageVersion Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="2.52.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.51.0" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.0" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.1" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.OpenApi" Version="2.0.0-preview2" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
+    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.1.0" />
     <!-- Benchmarks -->
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <!-- Testing -->
-    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
+    <PackageVersion Include="coverlet.MTP" Version="10.0.1" />
     <PackageVersion Include="FluentAssertions" Version="8.10.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-    <PackageVersion Include="NSubstitute" Version="6.0.0-rc.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageVersion Include="NSubstitute" Version="6.2.0" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
-    <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="4.0.0-pre.4" />
+    <PackageVersion Include="xunit.v3" Version="4.0.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="4.0.0" />
   </ItemGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,7 +1,10 @@
 ﻿{
   "sdk": {
-    "version": "10.0.101",
+    "version": "10.0.300",
     "rollForward": "latestFeature",
     "allowPrerelease": true
+  },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
   }
 }

--- a/src/Nagi.WinUI/App.xaml.cs
+++ b/src/Nagi.WinUI/App.xaml.cs
@@ -178,7 +178,6 @@ public partial class App : Application
 
             await HandleWindowActivationAsync(isStartupLaunch);
 
-            ShowElevationWarningIfNeededAsync();
             PerformPostLaunchTasks();
         }
         catch (Exception ex)
@@ -1128,54 +1127,6 @@ public partial class App : Application
         {
             Log.Warning(ex, "Failed to delete directory: {Path}", path);
         }
-    }
-
-    /// <summary>
-    ///     Shows a warning dialog if the application is running with administrator privileges.
-    ///     The FolderPicker API doesn't work properly when running elevated.
-    /// </summary>
-    private void ShowElevationWarningIfNeededAsync()
-    {
-        if (!ElevationHelper.IsRunningAsAdministrator()) return;
-
-        // Use the dispatcher to ensure the UI is fully loaded before showing the dialog.
-        MainDispatcherQueue?.TryEnqueue(DispatcherQueuePriority.Low, async () =>
-        {
-            // Wait briefly for XamlRoot to become available after page load.
-            const int maxRetries = 10;
-            for (var i = 0; i < maxRetries && RootWindow?.Content?.XamlRoot is null; i++)
-                await Task.Delay(100);
-
-            if (RootWindow?.Content?.XamlRoot is null)
-            {
-                _logger?.LogWarning("Could not show elevation warning: XamlRoot is not available.");
-                return;
-            }
-
-            _logger?.LogWarning("Application is running with administrator privileges. FolderPicker may not work.");
-
-            var dialog = new ContentDialog
-            {
-                Title = Nagi.WinUI.Resources.Strings.ElevationWarning_Title,
-                Content = Nagi.WinUI.Resources.Strings.ElevationWarning_Message,
-                PrimaryButtonText = Nagi.WinUI.Resources.Strings.ElevationWarning_Restart,
-                CloseButtonText = Nagi.WinUI.Resources.Strings.ElevationWarning_Continue,
-                DefaultButton = ContentDialogButton.Primary,
-                XamlRoot = RootWindow.Content.XamlRoot
-            };
-
-            DialogThemeHelper.ApplyThemeOverrides(dialog);
-            var result = await dialog.ShowAsync();
-            if (result == ContentDialogResult.Primary)
-            {
-                _logger?.LogInformation("User chose to restart without elevation.");
-                ElevationHelper.RestartWithoutElevation();
-            }
-            else
-            {
-                _logger?.LogInformation("User chose to continue running as administrator.");
-            }
-        });
     }
 
     /// <summary>

--- a/src/Nagi.WinUI/Dialogs/SmartPlaylistEditorDialog.xaml.cs
+++ b/src/Nagi.WinUI/Dialogs/SmartPlaylistEditorDialog.xaml.cs
@@ -5,7 +5,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Windows.Storage.Pickers;
+using Microsoft.Windows.Storage.Pickers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.UI.Xaml;
@@ -14,7 +14,6 @@ using Nagi.Core.Constants;
 using Nagi.Core.Models;
 using Nagi.Core.Services.Abstractions;
 using Nagi.WinUI.Helpers;
-using WinRT.Interop;
 
 namespace Nagi.WinUI.Dialogs;
 
@@ -182,9 +181,7 @@ public sealed partial class SmartPlaylistEditorDialog : ContentDialog
         try
         {
             _logger.LogDebug("Opening file picker for cover image.");
-            var picker = new FileOpenPicker();
-            var hwnd = WindowNative.GetWindowHandle(App.RootWindow);
-            InitializeWithWindow.Initialize(picker, hwnd);
+            var picker = new FileOpenPicker(App.RootWindow!.AppWindow.Id);
             foreach (var ext in FileExtensions.ImageFileExtensions)
                 picker.FileTypeFilter.Add(ext);
 

--- a/src/Nagi.WinUI/Pages/ArtistPage.xaml.cs
+++ b/src/Nagi.WinUI/Pages/ArtistPage.xaml.cs
@@ -9,8 +9,7 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Navigation;
 using Nagi.WinUI.ViewModels;
-using Windows.Storage.Pickers;
-using WinRT.Interop;
+using Microsoft.Windows.Storage.Pickers;
 using Nagi.Core.Constants;
 
 namespace Nagi.WinUI.Pages;
@@ -221,9 +220,7 @@ public sealed partial class ArtistPage : Page
     private async Task<string?> PickImageAsync()
     {
         _logger.LogDebug("Opening file picker for artist image.");
-        var picker = new FileOpenPicker();
-        var hwnd = WindowNative.GetWindowHandle(App.RootWindow);
-        InitializeWithWindow.Initialize(picker, hwnd);
+        var picker = new FileOpenPicker(App.RootWindow!.AppWindow.Id);
 
         foreach (var ext in FileExtensions.ImageFileExtensions)
             picker.FileTypeFilter.Add(ext);

--- a/src/Nagi.WinUI/Pages/ArtistViewPage.xaml.cs
+++ b/src/Nagi.WinUI/Pages/ArtistViewPage.xaml.cs
@@ -12,8 +12,7 @@ using Microsoft.UI.Xaml.Navigation;
 using Nagi.Core.Models;
 using Nagi.WinUI.Navigation;
 using Nagi.WinUI.ViewModels;
-using Windows.Storage.Pickers;
-using WinRT.Interop;
+using Microsoft.Windows.Storage.Pickers;
 using Nagi.Core.Constants;
 using Nagi.WinUI.Helpers;
 using Nagi.WinUI.Services.Abstractions;
@@ -397,9 +396,7 @@ public sealed partial class ArtistViewPage : Page
     private async Task<string?> PickImageAsync()
     {
         _logger.LogDebug("Opening file picker for artist image.");
-        var picker = new FileOpenPicker();
-        var hwnd = WindowNative.GetWindowHandle(App.RootWindow);
-        InitializeWithWindow.Initialize(picker, hwnd);
+        var picker = new FileOpenPicker(App.RootWindow!.AppWindow.Id);
 
         foreach (var ext in FileExtensions.ImageFileExtensions)
             picker.FileTypeFilter.Add(ext);

--- a/src/Nagi.WinUI/Pages/FolderPage.xaml.cs
+++ b/src/Nagi.WinUI/Pages/FolderPage.xaml.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
-using Windows.Storage.Pickers;
+using Microsoft.Windows.Storage.Pickers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.UI.Xaml;
@@ -8,7 +8,6 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Navigation;
 using Nagi.WinUI.Helpers;
 using Nagi.WinUI.ViewModels;
-using WinRT.Interop;
 
 namespace Nagi.WinUI.Pages;
 
@@ -86,10 +85,7 @@ public sealed partial class FolderPage : Page
         try
         {
             _logger.LogDebug("Add folder button clicked. Opening folder picker.");
-            var folderPicker = new FolderPicker();
-            var hwnd = WindowNative.GetWindowHandle(App.RootWindow);
-            InitializeWithWindow.Initialize(folderPicker, hwnd);
-            folderPicker.FileTypeFilter.Add("*");
+            var folderPicker = new FolderPicker(App.RootWindow!.AppWindow.Id);
 
             var folder = await folderPicker.PickSingleFolderAsync();
             if (folder != null)

--- a/src/Nagi.WinUI/Pages/PlaylistPage.xaml.cs
+++ b/src/Nagi.WinUI/Pages/PlaylistPage.xaml.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
-using Windows.Storage.Pickers;
+using Microsoft.Windows.Storage.Pickers;
 using Windows.System;
 using ImageEx;
 using Microsoft.Extensions.DependencyInjection;
@@ -14,7 +14,6 @@ using Microsoft.UI.Xaml.Navigation;
 using Nagi.Core.Constants;
 using Nagi.WinUI.Helpers;
 using Nagi.WinUI.ViewModels;
-using WinRT.Interop;
 
 namespace Nagi.WinUI.Pages;
 
@@ -388,9 +387,7 @@ public sealed partial class PlaylistPage : Page
     private async Task<string?> PickCoverImageAsync()
     {
         _logger.LogDebug("Opening file picker for cover image.");
-        var picker = new FileOpenPicker();
-        var hwnd = WindowNative.GetWindowHandle(App.RootWindow);
-        InitializeWithWindow.Initialize(picker, hwnd);
+        var picker = new FileOpenPicker(App.RootWindow!.AppWindow.Id);
         foreach (var ext in FileExtensions.ImageFileExtensions)
             picker.FileTypeFilter.Add(ext);
 

--- a/src/Nagi.WinUI/Program.cs
+++ b/src/Nagi.WinUI/Program.cs
@@ -7,6 +7,7 @@ using Windows.ApplicationModel.Activation;
 using Microsoft.Extensions.Logging;
 using Microsoft.UI.Dispatching;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Settings;
 using Nagi.WinUI.Helpers;
 using WinRT;
 
@@ -65,6 +66,11 @@ public static class Program
         logger?.LogInformation("Primary instance starting");
 
         LanguageBootstrapper.Bootstrap();
+
+        XamlOptionalChanges.EnableChange(XamlChangeId.DefaultStyleOptimizations);
+        XamlOptionalChanges.EnableChange(XamlChangeId.DeferContextFlyoutInit);
+        XamlOptionalChanges.EnableChange(XamlChangeId.IconNoGridOptimization);
+        XamlOptionalChanges.EnableChange(XamlChangeId.OptimizeApplyStyles);
 
         Application.Start(p =>
         {

--- a/src/Nagi.WinUI/Services/Implementations/UIService.cs
+++ b/src/Nagi.WinUI/Services/Implementations/UIService.cs
@@ -4,8 +4,8 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Windows.Storage;
-using Windows.Storage.Pickers;
 using Windows.System;
+using Microsoft.Windows.Storage.Pickers;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Nagi.WinUI.Controls;
@@ -55,10 +55,7 @@ public class UIService : IUIService
     {
         if (App.RootWindow is null) return null;
 
-        var folderPicker = new FolderPicker();
-        var hwnd = WindowNative.GetWindowHandle(App.RootWindow);
-        InitializeWithWindow.Initialize(folderPicker, hwnd);
-        folderPicker.FileTypeFilter.Add("*");
+        var folderPicker = new FolderPicker(App.RootWindow.AppWindow.Id);
 
         var selectedFolder = await folderPicker.PickSingleFolderAsync();
         return selectedFolder?.Path;
@@ -162,9 +159,7 @@ public class UIService : IUIService
     {
         if (App.RootWindow is null) return null;
 
-        var filePicker = new FileOpenPicker();
-        var hwnd = WindowNative.GetWindowHandle(App.RootWindow);
-        InitializeWithWindow.Initialize(filePicker, hwnd);
+        var filePicker = new FileOpenPicker(App.RootWindow.AppWindow.Id);
 
         foreach (var ext in fileTypes)
         {
@@ -179,9 +174,7 @@ public class UIService : IUIService
     {
         if (App.RootWindow is null) return [];
 
-        var filePicker = new FileOpenPicker();
-        var hwnd = WindowNative.GetWindowHandle(App.RootWindow);
-        InitializeWithWindow.Initialize(filePicker, hwnd);
+        var filePicker = new FileOpenPicker(App.RootWindow.AppWindow.Id);
 
         foreach (var ext in fileTypes)
         {

--- a/tests/Nagi.Core.Tests/MultiArtistTests.cs
+++ b/tests/Nagi.Core.Tests/MultiArtistTests.cs
@@ -10,7 +10,6 @@ using Nagi.Core.Services.Implementations;
 using Nagi.Core.Tests.Utils;
 using NSubstitute;
 using Xunit;
-using Xunit.Abstractions;
 using System.IO;
 
 namespace Nagi.Core.Tests;

--- a/tests/Nagi.Core.Tests/Nagi.Core.Tests.csproj
+++ b/tests/Nagi.Core.Tests/Nagi.Core.Tests.csproj
@@ -5,12 +5,12 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
+        <NoWarn>$(NoWarn);xUnit1051</NoWarn>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector">
+        <PackageReference Include="coverlet.MTP">
             <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="FluentAssertions" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" />
@@ -21,7 +21,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="SixLabors.ImageSharp" />
-        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.v3" />
         <PackageReference Include="xunit.runner.visualstudio">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Updates the compatible application, WinAppSDK, media, metadata, data, Azure, and test dependencies. Uses the modern WinAppSDK picker APIs and XAML optimizations, removes the obsolete elevation warning, and migrates tests and coverage to xUnit 4 with Microsoft Testing Platform.\n\nApplication Insights remains on 2.x because the Functions integration still requires its telemetry interfaces.