### PR TITLE
chore: bump version to 2.1.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,6 +13,6 @@
         <WindowsSdkVersion>10.0.26100</WindowsSdkVersion>
         <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
         <WindowsTargetPlatformMaxTestedVersion>10.0.26100.0</WindowsTargetPlatformMaxTestedVersion>
-        <AppxPackageVersion>2.1.0.0</AppxPackageVersion>
+        <AppxPackageVersion>2.1.1.0</AppxPackageVersion>
     </PropertyGroup>
 </Project>

--- a/src/Nagi.WinUI/Package.appxmanifest
+++ b/src/Nagi.WinUI/Package.appxmanifest
@@ -11,7 +11,7 @@
     <Identity
             Name="48743Nagi.Nagi"
             Publisher="CN=83B77A15-7BA2-452B-A4A0-9DD253FA3D0E"
-            Version="2.1.0.0"/>
+            Version="2.1.1.0"/>
 
     <Properties>
         <DisplayName>ms-resource:Resources/AppName</DisplayName>


### PR DESCRIPTION
Bumps the app and package versions to 2.1.1 for the callback compatibility release.