### PR TITLE
fix: keep active searches visible

### DIFF
--- a/src/Nagi.WinUI/Pages/AlbumPage.xaml.cs
+++ b/src/Nagi.WinUI/Pages/AlbumPage.xaml.cs
@@ -94,7 +94,11 @@ public sealed partial class AlbumPage : Page
     private void OnPageLoaded(object sender, RoutedEventArgs e)
     {
         _logger.LogDebug("AlbumPage loaded. Setting initial visual state.");
-        VisualStateManager.GoToState(this, "SearchCollapsed", false);
+        _isSearchExpanded = !string.IsNullOrWhiteSpace(ViewModel.SearchTerm);
+        ToolTipService.SetToolTip(SearchToggleButton, _isSearchExpanded
+            ? Nagi.WinUI.Resources.Strings.AlbumPage_SearchButton_Close_ToolTip
+            : Nagi.WinUI.Resources.Strings.AlbumPage_SearchButton_Search_ToolTip);
+        VisualStateManager.GoToState(this, _isSearchExpanded ? "SearchExpanded" : "SearchCollapsed", false);
         Loaded -= OnPageLoaded;
     }
 

--- a/src/Nagi.WinUI/Pages/ArtistPage.xaml.cs
+++ b/src/Nagi.WinUI/Pages/ArtistPage.xaml.cs
@@ -102,7 +102,11 @@ public sealed partial class ArtistPage : Page
     private void OnPageLoaded(object sender, RoutedEventArgs e)
     {
         _logger.LogDebug("ArtistPage loaded. Setting initial visual state.");
-        VisualStateManager.GoToState(this, "SearchCollapsed", false);
+        _isSearchExpanded = !string.IsNullOrWhiteSpace(ViewModel.SearchTerm);
+        ToolTipService.SetToolTip(SearchToggleButton, _isSearchExpanded
+            ? Nagi.WinUI.Resources.Strings.ArtistPage_SearchButton_Close_ToolTip
+            : Nagi.WinUI.Resources.Strings.ArtistPage_SearchButton_Search_ToolTip);
+        VisualStateManager.GoToState(this, _isSearchExpanded ? "SearchExpanded" : "SearchCollapsed", false);
         Loaded -= OnPageLoaded;
     }
 

--- a/src/Nagi.WinUI/Pages/GenrePage.xaml.cs
+++ b/src/Nagi.WinUI/Pages/GenrePage.xaml.cs
@@ -92,7 +92,11 @@ public sealed partial class GenrePage : Page
     private void OnPageLoaded(object sender, RoutedEventArgs e)
     {
         _logger.LogDebug("GenrePage loaded. Setting initial visual state.");
-        VisualStateManager.GoToState(this, "SearchCollapsed", false);
+        _isSearchExpanded = !string.IsNullOrWhiteSpace(ViewModel.SearchTerm);
+        ToolTipService.SetToolTip(SearchToggleButton, _isSearchExpanded
+            ? Nagi.WinUI.Resources.Strings.GenrePage_SearchButton_Close_ToolTip
+            : Nagi.WinUI.Resources.Strings.GenrePage_SearchButton_Search_ToolTip);
+        VisualStateManager.GoToState(this, _isSearchExpanded ? "SearchExpanded" : "SearchCollapsed", false);
         Loaded -= OnPageLoaded;
     }
 

--- a/src/Nagi.WinUI/Pages/LibraryPage.xaml.cs
+++ b/src/Nagi.WinUI/Pages/LibraryPage.xaml.cs
@@ -114,7 +114,11 @@ public sealed partial class LibraryPage : Page
     private void OnPageLoaded(object sender, RoutedEventArgs e)
     {
         _logger.LogDebug("LibraryPage loaded. Setting initial visual state.");
-        VisualStateManager.GoToState(this, "SearchCollapsed", false);
+        _isSearchExpanded = !string.IsNullOrWhiteSpace(ViewModel.SearchTerm);
+        ToolTipService.SetToolTip(SearchToggleButton, _isSearchExpanded
+            ? Nagi.WinUI.Resources.Strings.LibraryPage_SearchButton_Close_ToolTip
+            : Nagi.WinUI.Resources.Strings.LibraryPage_SearchButton_Search_ToolTip);
+        VisualStateManager.GoToState(this, _isSearchExpanded ? "SearchExpanded" : "SearchCollapsed", false);
         Loaded -= OnPageLoaded;
     }
 

--- a/src/Nagi.WinUI/Pages/PlaylistPage.xaml.cs
+++ b/src/Nagi.WinUI/Pages/PlaylistPage.xaml.cs
@@ -41,7 +41,11 @@ public sealed partial class PlaylistPage : Page
         try
         {
             _logger.LogDebug("PlaylistPage loaded. Setting initial visual state and loading playlists...");
-            VisualStateManager.GoToState(this, "SearchCollapsed", false);
+            _isSearchExpanded = !string.IsNullOrWhiteSpace(ViewModel.SearchTerm);
+            ToolTipService.SetToolTip(SearchToggleButton, _isSearchExpanded
+                ? Nagi.WinUI.Resources.Strings.PlaylistPage_SearchButton_Close_ToolTip
+                : Nagi.WinUI.Resources.Strings.PlaylistPage_SearchButton_Search_ToolTip);
+            VisualStateManager.GoToState(this, _isSearchExpanded ? "SearchExpanded" : "SearchCollapsed", false);
             await ViewModel.LoadPlaylistsCommand.ExecuteAsync(null);
             _logger.LogDebug("Finished loading playlists.");
         }


### PR DESCRIPTION
Closes #156.\n\nWhen a persistent top-level view is revisited, its search box now stays expanded if a filter is active. The query remains visible and the existing close button clears it. This covers Library, Playlists, Artists, Albums, and Genres.