### PR TITLE
fix: make lyrics page button toggle

### DIFF
--- a/src/Nagi.WinUI/MainPage.xaml
+++ b/src/Nagi.WinUI/MainPage.xaml
@@ -73,8 +73,18 @@
                 <Button
                     ToolTipService.ToolTip="{x:Bind DynamicToolTip, Mode=OneTime}"
                     Style="{StaticResource LyricsButtonStyle}"
-                    Command="{x:Bind Command}">
-                    <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="{x:Bind DynamicIcon, Mode=OneWay}" />
+                    Click="LyricsButton_Click">
+                    <Grid Width="40" Height="40" Margin="-8">
+                        <Border
+                            Background="{ThemeResource ControlFillColorSecondaryBrush}"
+                            CornerRadius="{ThemeResource ControlCornerRadius}"
+                            Visibility="{Binding DataContext.IsLyricsPageActive, ElementName=MainPageRoot, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                        <FontIcon
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center"
+                            FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                            Glyph="{x:Bind DynamicIcon, Mode=OneWay}" />
+                    </Grid>
                 </Button>
             </DataTemplate>
 

--- a/src/Nagi.WinUI/MainPage.xaml.cs
+++ b/src/Nagi.WinUI/MainPage.xaml.cs
@@ -166,6 +166,14 @@ public sealed partial class MainPage : UserControl, ICustomTitleBarProvider
         }
     }
 
+    private void LyricsButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (ContentFrame.CurrentSourcePageType == typeof(LyricsPage))
+            TryGoBack();
+        else
+            ContentFrame.Navigate(typeof(LyricsPage));
+    }
+
     // Synchronizes the NavigationView's selected item with the currently displayed page.
     private void UpdateNavViewSelection(Type currentPageType)
     {
@@ -492,6 +500,7 @@ public sealed partial class MainPage : UserControl, ICustomTitleBarProvider
         {
             var isDetailPage = _detailPageToParentTagMap.ContainsKey(e.SourcePageType);
             var isLyricsPage = e.SourcePageType == typeof(LyricsPage);
+            ViewModel.IsLyricsPageActive = isLyricsPage;
 
             if (AppTitleBar != null)
             {

--- a/src/Nagi.WinUI/ViewModels/PlayerViewModel.cs
+++ b/src/Nagi.WinUI/ViewModels/PlayerViewModel.cs
@@ -11,7 +11,6 @@ using Nagi.Core.Services.Abstractions;
 using Nagi.Core.Services.Data;
 using Nagi.WinUI.Models;
 using Nagi.WinUI.Navigation;
-using Nagi.WinUI.Pages;
 using Nagi.WinUI.Services.Abstractions;
 using Nagi.WinUI.Helpers;
 using Nagi.WinUI.Resources;
@@ -143,6 +142,8 @@ public partial class PlayerViewModel : ObservableObject
     [NotifyCanExecuteChangedFor(nameof(CancelGlobalOperationCommand))]
     public partial bool IsGlobalOperationCancellable { get; set; }
     [ObservableProperty] public partial bool IsQueueViewVisible { get; set; }
+
+    [ObservableProperty] public partial bool IsLyricsPageActive { get; set; }
 
     [ObservableProperty] public partial bool IsVolumeControlVisible { get; set; }
 
@@ -296,7 +297,6 @@ public partial class PlayerViewModel : ObservableObject
                     button.DynamicToolTip = Strings.Player_NextButton_ToolTip;
                     break;
                 case "Lyrics":
-                    button.Command = GoToLyricsPageCommand;
                     button.DynamicIcon = "\uE8D2"; // Lyrics glyph
                     button.DynamicToolTip = Strings.Player_LyricsButton_ToolTip;
                     break;
@@ -470,12 +470,6 @@ public partial class PlayerViewModel : ObservableObject
 
         // Otherwise fallback to checking if we have a current track.
         return CurrentPlayingTrack != null;
-    }
-
-    [RelayCommand]
-    private void GoToLyricsPage()
-    {
-        _navigationService.Navigate(typeof(LyricsPage));
     }
 
     partial void OnIsMutedChanged(bool value)


### PR DESCRIPTION
Closes #161.\n\n- highlights the lyrics button while the lyrics page is active\n- clicking it again returns to the previous page\n- keeps the behavior in the shell that owns the navigation frame