### PR TITLE
fix: preserve native multi-value genres

### DIFF
--- a/src/Nagi.Core/Services/Implementations/AtlMetadataService.cs
+++ b/src/Nagi.Core/Services/Implementations/AtlMetadataService.cs
@@ -15,6 +15,8 @@ namespace Nagi.Core.Services.Implementations;
 /// </summary>
 public class AtlMetadataService : IMetadataService, IDisposable
 {
+    private const char AtlMultiValueSeparator = '\u001F';
+    private const char CombinedValueSeparator = ';';
     private readonly IFileSystemService _fileSystem;
     private readonly IImageProcessor _imageProcessor;
     private readonly ILogger<AtlMetadataService> _logger;
@@ -27,6 +29,11 @@ public class AtlMetadataService : IMetadataService, IDisposable
     private readonly object _genreSplitCharactersLock = new();
     private string? _cachedGenreSplitCharacters;
     private bool _disposed;
+
+    static AtlMetadataService()
+    {
+        ATL.Settings.DisplayValueSeparator = AtlMultiValueSeparator;
+    }
 
     public AtlMetadataService(IImageProcessor imageProcessor, IFileSystemService fileSystem,
         IPathConfiguration pathConfig, ILogger<AtlMetadataService> logger, ISettingsService settingsService)
@@ -215,12 +222,13 @@ public class AtlMetadataService : IMetadataService, IDisposable
         // If no split characters are provided, normalize and return the whole string
         if (string.IsNullOrEmpty(splitCharacters))
         {
-            var normalized = ArtistNameHelper.NormalizeStringCore(input);
+            var normalized = ArtistNameHelper.NormalizeStringCore(
+                input.Replace(AtlMultiValueSeparator, CombinedValueSeparator));
             return normalized != null ? [normalized] : [];
         }
 
         return input
-            .Split(splitCharacters.ToCharArray(), StringSplitOptions.RemoveEmptyEntries)
+            .Split([.. splitCharacters, AtlMultiValueSeparator], StringSplitOptions.RemoveEmptyEntries)
             .Select(s => ArtistNameHelper.NormalizeStringCore(s))
             .Where(s => !string.IsNullOrEmpty(s))
             .Select(s => s!)

--- a/tests/Nagi.Core.Tests/AtlMetadataServiceTests.cs
+++ b/tests/Nagi.Core.Tests/AtlMetadataServiceTests.cs
@@ -202,6 +202,21 @@ public class AtlMetadataServiceTests : IDisposable
         result.Genres.Should().ContainInOrder("Rock", "Pop", "Indie", "Jazz");
     }
 
+    [Fact]
+    public async Task ExtractMetadataAsync_WithNativeMultiValueGenres_PreservesGenreBoundaries()
+    {
+        var filePath = CreateTestAudioFile("multigenre.mp3", track =>
+        {
+            track.Genre = "2-Step\u02F5Funky Breaks";
+        });
+
+        _settingsService.GetGenreSplitCharactersAsync().Returns(Task.FromResult("\\"));
+
+        var result = await _metadataService.ExtractMetadataAsync(filePath);
+
+        result.Genres.Should().ContainInOrder("2-Step", "Funky Breaks");
+    }
+
     /// <summary>
     ///     Verifies that the service provides sensible default values for metadata
     ///     when processing an audio file with no tags.


### PR DESCRIPTION
Closes #158.\n\nATL previously converted native multi-value boundaries to a semicolon before Nagi applied the configured separators. This preserves that boundary internally and splits it when genre splitting is enabled, while retaining the existing combined-semicolon behavior when splitting is disabled.