### PR TITLE
feat: queue dropped files and folders

### DIFF
--- a/src/Nagi.Core/Services/Abstractions/IMusicPlaybackService.cs
+++ b/src/Nagi.Core/Services/Abstractions/IMusicPlaybackService.cs
@@ -250,6 +250,16 @@ public interface IMusicPlaybackService : IDisposable, IAsyncDisposable
     Task PlayTransientFileAsync(string filePath);
 
     /// <summary>
+    ///     Adds files that are not necessarily in the library to the end of the queue.
+    /// </summary>
+    Task AddTransientFilesToQueueAsync(IEnumerable<string> filePaths);
+
+    /// <summary>
+    ///     Resolves library and transient tracks for queue display.
+    /// </summary>
+    Task<IReadOnlyDictionary<Guid, Song>> GetQueueTracksAsync(IEnumerable<Guid> songIds);
+
+    /// <summary>
     ///     Sets the player volume and persists the value.
     /// </summary>
     /// <param name="volume">The new volume level (0.0 to 1.0).</param>

--- a/src/Nagi.Core/Services/Implementations/MusicPlaybackService.cs
+++ b/src/Nagi.Core/Services/Implementations/MusicPlaybackService.cs
@@ -26,6 +26,8 @@ public class MusicPlaybackService : IMusicPlaybackService, IDisposable
     private DateTime? _currentListenStartedUtc;
     private List<Guid> _playbackQueue = new();
     private List<Guid> _shuffledQueue = new();
+    private readonly Dictionary<Guid, Song> _transientTracks = new();
+    private readonly Dictionary<string, Guid> _transientTrackIdsByPath = new(StringComparer.OrdinalIgnoreCase);
 
     // Reverse index dictionaries for O(1) lookups in large queues (500k+ songs)
     private Dictionary<Guid, int> _playbackQueueIndex = new();
@@ -279,6 +281,7 @@ public class MusicPlaybackService : IMusicPlaybackService, IDisposable
                 }
             }
 
+            PruneTransientTracks();
             QueueChanged?.Invoke();
             UpdateSmtcControls();
         }
@@ -302,6 +305,49 @@ public class MusicPlaybackService : IMusicPlaybackService, IDisposable
     public async Task PlayTransientFileAsync(string filePath)
     {
         _logger.LogDebug("Playing transient file: {FilePath}", filePath);
+        var transientSong = await CreateTransientSongAsync(filePath).ConfigureAwait(false);
+
+        if (CurrentListenHistoryId.HasValue)
+        {
+            var sessionId = CurrentListenHistoryId.Value;
+            var position = _audioPlayer.CurrentPosition;
+            CurrentListenHistoryId = null;
+            FireAndForgetSafe(async () => await _libraryService.FinalizeListenSessionAsync(sessionId, position, PlaybackEndReason.Skipped).ConfigureAwait(false), "Finalizing session on Transient Playback", trackForDisposal: true);
+        }
+
+        _isEligibilityMarked = false;
+
+        IsTransitioningTrack = true;
+        ClearQueuesInternal();
+        RegisterTransientTrack(transientSong);
+        QueueChanged?.Invoke();
+
+        CurrentTrack = transientSong;
+        CurrentQueueIndex = -1;
+        CurrentListenHistoryId = null;
+        _currentContext = new PlaybackContext(PlaybackContextType.Transient, null);
+
+        // Track listens for transient playback only when the file maps to a known library song.
+        // Truly external files remain untracked because ListenHistory requires a Song FK.
+        var existingLibrarySong = await _libraryService.GetSongByFilePathAsync(filePath).ConfigureAwait(false);
+        if (existingLibrarySong != null)
+        {
+            var listenStartedUtc = DateTime.UtcNow;
+            CurrentListenHistoryId = await _libraryService
+                .StartListenSessionAsync(existingLibrarySong.Id, _currentContext)
+                .ConfigureAwait(false);
+            _currentListenStartedUtc = CurrentListenHistoryId.HasValue ? listenStartedUtc : null;
+        }
+
+        await _audioPlayer.LoadAsync(CurrentTrack).ConfigureAwait(false);
+        await _audioPlayer.PlayAsync().ConfigureAwait(false);
+        UpdateSmtcControls();
+
+        TrackChanged?.Invoke();
+    }
+
+    private async Task<Song> CreateTransientSongAsync(string filePath)
+    {
         var metadata = await _metadataService.ExtractMetadataAsync(filePath).ConfigureAwait(false);
 
         // Filter out null/empty artist names and provide fallback if all are invalid
@@ -324,7 +370,7 @@ public class MusicPlaybackService : IMusicPlaybackService, IDisposable
             validAlbumArtists = validArtists;
         }
 
-        var transientSong = new Song
+        return new Song
         {
             FilePath = filePath,
             Title = metadata.Title,
@@ -350,45 +396,102 @@ public class MusicPlaybackService : IMusicPlaybackService, IDisposable
                 }).ToList()
             },
             Duration = metadata.Duration,
-            AlbumArtUriFromTrack = metadata.CoverArtUri
+            AlbumArtUriFromTrack = metadata.CoverArtUri,
+            Lyrics = metadata.Lyrics,
+            LrcFilePath = metadata.LrcFilePath
         };
+    }
 
-        if (CurrentListenHistoryId.HasValue)
+    public async Task AddTransientFilesToQueueAsync(IEnumerable<string> filePaths)
+    {
+        var paths = filePaths?
+            .Where(path => !string.IsNullOrWhiteSpace(path))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList() ?? [];
+        if (paths.Count == 0) return;
+
+        var songs = new List<Song>(paths.Count);
+        foreach (var path in paths)
         {
-            var sessionId = CurrentListenHistoryId.Value;
-            var position = _audioPlayer.CurrentPosition;
-            CurrentListenHistoryId = null;
-            FireAndForgetSafe(async () => await _libraryService.FinalizeListenSessionAsync(sessionId, position, PlaybackEndReason.Skipped).ConfigureAwait(false), "Finalizing session on Transient Playback", trackForDisposal: true);
+            if (_transientTrackIdsByPath.TryGetValue(path, out var transientId)
+                && _transientTracks.TryGetValue(transientId, out var existingTransient))
+            {
+                songs.Add(existingTransient);
+                continue;
+            }
+
+            var librarySong = await _libraryService.GetSongByFilePathAsync(path).ConfigureAwait(false);
+            if (librarySong != null)
+            {
+                songs.Add(librarySong);
+                continue;
+            }
+
+            var transientSong = await CreateTransientSongAsync(path).ConfigureAwait(false);
+            RegisterTransientTrack(transientSong);
+            songs.Add(transientSong);
         }
 
-        _isEligibilityMarked = false;
-
-        IsTransitioningTrack = true;
-        ClearQueuesInternal();
-        QueueChanged?.Invoke();
-
-        CurrentTrack = transientSong;
-        CurrentQueueIndex = -1;
-        CurrentListenHistoryId = null;
-        _currentContext = new PlaybackContext(PlaybackContextType.Transient, null);
-
-        // Track listens for transient playback only when the file maps to a known library song.
-        // Truly external files remain untracked because ListenHistory requires a Song FK.
-        var existingLibrarySong = await _libraryService.GetSongByFilePathAsync(filePath).ConfigureAwait(false);
-        if (existingLibrarySong != null)
+        using (BeginQueueUpdate())
         {
-            var listenStartedUtc = DateTime.UtcNow;
-            CurrentListenHistoryId = await _libraryService
-                .StartListenSessionAsync(existingLibrarySong.Id, _currentContext)
-                .ConfigureAwait(false);
-            _currentListenStartedUtc = CurrentListenHistoryId.HasValue ? listenStartedUtc : null;
+            if (_playbackQueue.Count == 0 && CurrentTrack != null)
+            {
+                _playbackQueue.Add(CurrentTrack.Id);
+            }
+
+            var queuedIds = _playbackQueue.ToHashSet();
+            foreach (var song in songs)
+            {
+                if (queuedIds.Add(song.Id)) _playbackQueue.Add(song.Id);
+            }
         }
 
-        await _audioPlayer.LoadAsync(CurrentTrack).ConfigureAwait(false);
-        await _audioPlayer.PlayAsync().ConfigureAwait(false);
-        UpdateSmtcControls();
+        if (CurrentTrack == null && _playbackQueue.Count > 0)
+        {
+            _currentContext = new PlaybackContext(PlaybackContextType.Transient, null);
+            await PlayQueueItemAsync(0).ConfigureAwait(false);
+        }
+    }
 
-        TrackChanged?.Invoke();
+    public async Task<IReadOnlyDictionary<Guid, Song>> GetQueueTracksAsync(IEnumerable<Guid> songIds)
+    {
+        var ids = songIds?.Distinct().ToList() ?? [];
+        var result = new Dictionary<Guid, Song>(ids.Count);
+        var libraryIds = new List<Guid>(ids.Count);
+
+        foreach (var id in ids)
+        {
+            if (_transientTracks.TryGetValue(id, out var transientTrack))
+                result[id] = transientTrack;
+            else
+                libraryIds.Add(id);
+        }
+
+        if (libraryIds.Count > 0)
+        {
+            var libraryTracks = await _libraryService.GetSongsByIdsAsync(libraryIds).ConfigureAwait(false);
+            foreach (var pair in libraryTracks) result[pair.Key] = pair.Value;
+        }
+
+        return result;
+    }
+
+    private void RegisterTransientTrack(Song song)
+    {
+        _transientTracks[song.Id] = song;
+        _transientTrackIdsByPath[song.FilePath] = song.Id;
+    }
+
+    private void PruneTransientTracks()
+    {
+        var retainedIds = _playbackQueue.ToHashSet();
+        if (CurrentTrack != null) retainedIds.Add(CurrentTrack.Id);
+
+        foreach (var id in _transientTracks.Keys.Where(id => !retainedIds.Contains(id)).ToList())
+        {
+            _transientTrackIdsByPath.Remove(_transientTracks[id].FilePath);
+            _transientTracks.Remove(id);
+        }
     }
 
     public Task PlayAsync(Song song)
@@ -962,7 +1065,8 @@ public class MusicPlaybackService : IMusicPlaybackService, IDisposable
         while (skipCount < maxSkipAttempts && currentIndex >= 0 && currentIndex < _playbackQueue.Count)
         {
             var songId = _playbackQueue[currentIndex];
-            song = await _libraryService.GetSongByIdAsync(songId).ConfigureAwait(false);
+            song = _transientTracks.GetValueOrDefault(songId)
+                   ?? await _libraryService.GetSongByIdAsync(songId).ConfigureAwait(false);
 
             if (song != null)
             {
@@ -1019,14 +1123,23 @@ public class MusicPlaybackService : IMusicPlaybackService, IDisposable
 
         CurrentTrack = song;
         CurrentQueueIndex = currentIndex;
+        PruneTransientTracks();
 
-        // Start and assign the listen session before media load can raise MediaOpened/TrackChanged.
-        // This guarantees presence listeners can observe a non-null CurrentListenHistoryId.
-        var listenStartedUtc = DateTime.UtcNow;
-        CurrentListenHistoryId = await _libraryService
-            .StartListenSessionAsync(CurrentTrack.Id, _currentContext)
-            .ConfigureAwait(false);
-        _currentListenStartedUtc = CurrentListenHistoryId.HasValue ? listenStartedUtc : null;
+        if (_transientTracks.ContainsKey(CurrentTrack.Id))
+        {
+            CurrentListenHistoryId = null;
+            _currentListenStartedUtc = null;
+        }
+        else
+        {
+            // Start and assign the listen session before media load can raise MediaOpened/TrackChanged.
+            // This guarantees presence listeners can observe a non-null CurrentListenHistoryId.
+            var listenStartedUtc = DateTime.UtcNow;
+            CurrentListenHistoryId = await _libraryService
+                .StartListenSessionAsync(CurrentTrack.Id, _currentContext)
+                .ConfigureAwait(false);
+            _currentListenStartedUtc = CurrentListenHistoryId.HasValue ? listenStartedUtc : null;
+        }
 
         if (IsShuffleEnabled)
         {
@@ -1045,8 +1158,8 @@ public class MusicPlaybackService : IMusicPlaybackService, IDisposable
 
         await _audioPlayer.LoadAsync(CurrentTrack).ConfigureAwait(false);
 
-        // Apply ReplayGain if enabled and available in database
-        await ApplyReplayGainIfEnabledAsync().ConfigureAwait(false);
+        if (!_transientTracks.ContainsKey(CurrentTrack.Id))
+            await ApplyReplayGainIfEnabledAsync().ConfigureAwait(false);
 
         await _audioPlayer.PlayAsync().ConfigureAwait(false);
         // Note: UpdateSmtcControls() is called by OnAudioPlayerMediaOpened after LoadAsync completes
@@ -1068,13 +1181,19 @@ public class MusicPlaybackService : IMusicPlaybackService, IDisposable
     {
         if (!_isInitialized) return;
 
+        var playbackQueue = _playbackQueue.Where(id => !_transientTracks.ContainsKey(id)).ToList();
+        var shuffledQueue = _shuffledQueue.Where(id => !_transientTracks.ContainsKey(id)).ToList();
+        var currentTrackId = CurrentTrack is not null && !_transientTracks.ContainsKey(CurrentTrack.Id)
+            ? CurrentTrack.Id
+            : (Guid?)null;
+
         var state = new PlaybackState
         {
-            CurrentTrackId = CurrentTrack?.Id,
-            PlaybackQueueTrackIds = _playbackQueue.ToList(),
-            CurrentPlaybackQueueIndex = CurrentQueueIndex,
-            ShuffledQueueTrackIds = IsShuffleEnabled ? _shuffledQueue.ToList() : new List<Guid>(),
-            CurrentShuffledQueueIndex = CurrentShuffledIndex
+            CurrentTrackId = currentTrackId,
+            PlaybackQueueTrackIds = playbackQueue,
+            CurrentPlaybackQueueIndex = currentTrackId.HasValue ? playbackQueue.IndexOf(currentTrackId.Value) : -1,
+            ShuffledQueueTrackIds = IsShuffleEnabled ? shuffledQueue : [],
+            CurrentShuffledQueueIndex = currentTrackId.HasValue ? shuffledQueue.IndexOf(currentTrackId.Value) : -1
         };
         await _settingsService.SavePlaybackStateAsync(state).ConfigureAwait(false);
     }
@@ -1327,6 +1446,8 @@ public class MusicPlaybackService : IMusicPlaybackService, IDisposable
         _shuffledQueue.Clear();
         _playbackQueueIndex.Clear();
         _shuffledQueueIndex.Clear();
+        _transientTracks.Clear();
+        _transientTrackIdsByPath.Clear();
         CurrentTrack = null;
         CurrentQueueIndex = -1;
         CurrentShuffledIndex = -1;

--- a/src/Nagi.WinUI/MainPage.xaml
+++ b/src/Nagi.WinUI/MainPage.xaml
@@ -97,7 +97,12 @@
                                 Placement="Top"
                                 Opened="QueueFlyout_Opened"
                                 Closed="QueueFlyout_Closed">
-                            <Grid Width="300" Height="400">
+                            <Grid
+                                Width="300"
+                                Height="400"
+                                AllowDrop="True"
+                                DragOver="QueueFlyout_DragOver"
+                                Drop="QueueFlyout_Drop">
                                 <Grid.RowDefinitions>
                                     <RowDefinition Height="Auto" />
                                     <RowDefinition Height="*" />

--- a/src/Nagi.WinUI/MainPage.xaml.cs
+++ b/src/Nagi.WinUI/MainPage.xaml.cs
@@ -5,7 +5,9 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
+using Windows.ApplicationModel.DataTransfer;
 using Windows.Foundation.Metadata;
+using Windows.Storage;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.UI.Xaml;
@@ -15,6 +17,7 @@ using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Media.Animation;
 using Microsoft.UI.Xaml.Navigation;
 using Nagi.Core.Services.Abstractions;
+using Nagi.Core.Constants;
 using Nagi.WinUI.Controls;
 using Nagi.WinUI.Pages;
 using Nagi.WinUI.Resources;
@@ -172,6 +175,54 @@ public sealed partial class MainPage : UserControl, ICustomTitleBarProvider
             TryGoBack();
         else
             ContentFrame.Navigate(typeof(LyricsPage));
+    }
+
+    private void QueueFlyout_DragOver(object sender, DragEventArgs e)
+    {
+        if (e.DataView.Contains(StandardDataFormats.StorageItems))
+            e.AcceptedOperation = DataPackageOperation.Copy;
+    }
+
+    private async void QueueFlyout_Drop(object sender, DragEventArgs e)
+    {
+        if (!e.DataView.Contains(StandardDataFormats.StorageItems)) return;
+
+        try
+        {
+            var paths = new List<string>();
+            var items = await e.DataView.GetStorageItemsAsync();
+            foreach (var item in items.OrderBy(item => item.Name, StringComparer.OrdinalIgnoreCase))
+                await CollectMusicFilesAsync(item, paths);
+
+            await ViewModel.AddFilesToQueueAsync(paths);
+            e.Handled = true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to add dropped files to the playback queue.");
+        }
+    }
+
+    private async Task CollectMusicFilesAsync(IStorageItem item, List<string> paths)
+    {
+        if (item is StorageFile file)
+        {
+            if (FileExtensions.MusicFileExtensions.Contains(file.FileType)) paths.Add(file.Path);
+            return;
+        }
+
+        if (item is not StorageFolder folder) return;
+
+        try
+        {
+            var children = await folder.GetItemsAsync();
+            foreach (var child in children.OrderBy(child => child.Name, StringComparer.OrdinalIgnoreCase))
+                await CollectMusicFilesAsync(child, paths);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Could not read dropped folder {FolderPath}.", folder.Path);
+        }
     }
 
     // Synchronizes the NavigationView's selected item with the currently displayed page.

--- a/src/Nagi.WinUI/ViewModels/LyricsPageViewModel.cs
+++ b/src/Nagi.WinUI/ViewModels/LyricsPageViewModel.cs
@@ -297,7 +297,7 @@ public partial class LyricsPageViewModel : ObservableObject, IDisposable
             await Task.WhenAll(fullSongTask, localLrcTask).ConfigureAwait(false);
             if (cancellationToken.IsCancellationRequested) return;
 
-            var fullSong = fullSongTask.Result;
+            var fullSong = fullSongTask.Result ?? song;
             var localLrc = localLrcTask.Result;
 
             // Priority 1: Local .lrc sidecar (synced lyrics)

--- a/src/Nagi.WinUI/ViewModels/PlayerViewModel.cs
+++ b/src/Nagi.WinUI/ViewModels/PlayerViewModel.cs
@@ -651,7 +651,7 @@ public partial class PlayerViewModel : ObservableObject
             if (token.IsCancellationRequested) return;
 
             // Fetch metadata for the IDs we're about to display
-            var fetchedSongs = await _libraryService.GetSongsByIdsAsync(idsToShow).ConfigureAwait(true);
+            var fetchedSongs = await _playbackService.GetQueueTracksAsync(idsToShow).ConfigureAwait(true);
 
             // Check for cancellation or disposal after the async call, before updating UI
             if (token.IsCancellationRequested) return;
@@ -676,6 +676,9 @@ public partial class PlayerViewModel : ObservableObject
             _logger.LogError(ex, "Failed to update queue display");
         }
     }
+
+    public Task AddFilesToQueueAsync(IEnumerable<string> filePaths) =>
+        _playbackService.AddTransientFilesToQueueAsync(filePaths);
 
     private void UpdateVolumeIconGlyph()
     {

--- a/tests/Nagi.Core.Tests/MusicPlaybackServiceTests.cs
+++ b/tests/Nagi.Core.Tests/MusicPlaybackServiceTests.cs
@@ -94,7 +94,13 @@ public class MusicPlaybackServiceTests
     {
         // Arrange
         const string filePath = "C:\\temp\\transient.mp3";
-        var metadata = new SongFileMetadata { Title = "Transient Song", Artists = new List<string> { "Temp Artist" } };
+        var metadata = new SongFileMetadata
+        {
+            Title = "Transient Song",
+            Artists = new List<string> { "Temp Artist" },
+            Lyrics = "Embedded lyrics",
+            LrcFilePath = "C:\\temp\\transient.lrc"
+        };
         _metadataService.ExtractMetadataAsync(filePath).Returns(metadata);
         await _service.InitializeAsync();
         await _service.PlayAsync(_testSongs); // Pre-load a queue
@@ -108,6 +114,8 @@ public class MusicPlaybackServiceTests
         _service.CurrentTrack.Should().NotBeNull();
         _service.CurrentTrack!.Title.Should().Be("Transient Song");
         _service.CurrentTrack!.ArtistName.Should().Be("Temp Artist");
+        _service.CurrentTrack!.Lyrics.Should().Be("Embedded lyrics");
+        _service.CurrentTrack!.LrcFilePath.Should().Be("C:\\temp\\transient.lrc");
         _service.CurrentQueueIndex.Should().Be(-1);
         await _audioPlayer.Received(1).LoadAsync(Arg.Is<Song>(s => s != null && s.FilePath == filePath));
         await _audioPlayer.Received(1).PlayAsync();
@@ -132,6 +140,36 @@ public class MusicPlaybackServiceTests
         // Assert
         _service.CurrentTrack.Should().NotBeNull();
         _service.CurrentTrack!.ArtistName.Should().Be("Artist 1 & Artist 2");
+    }
+
+    [Fact]
+    public async Task AddTransientFilesToQueueAsync_AppendsAndPlaysExternalFiles()
+    {
+        var firstPath = "C:\\temp\\first.mp3";
+        var secondPath = "C:\\temp\\second.flac";
+        _metadataService.ExtractMetadataAsync(firstPath).Returns(new SongFileMetadata { Title = "First" });
+        _metadataService.ExtractMetadataAsync(secondPath).Returns(new SongFileMetadata { Title = "Second" });
+        await _service.InitializeAsync();
+        await _service.PlayAsync(_testSongs);
+        _audioPlayer.ClearReceivedCalls();
+        _libraryService.ClearReceivedCalls();
+
+        await _service.AddTransientFilesToQueueAsync([firstPath, secondPath]);
+
+        _service.PlaybackQueue.Should().HaveCount(_testSongs.Count + 2);
+        var externalIds = _service.PlaybackQueue.TakeLast(2).ToList();
+        var tracks = await _service.GetQueueTracksAsync(externalIds);
+        externalIds.Select(id => tracks[id].Title).Should().ContainInOrder("First", "Second");
+
+        await _service.SavePlaybackStateAsync();
+        await _settingsService.Received().SavePlaybackStateAsync(Arg.Is<PlaybackState>(state =>
+            state.PlaybackQueueTrackIds.SequenceEqual(_testSongs.Select(song => song.Id))));
+
+        await _service.PlayQueueItemAsync(_testSongs.Count);
+
+        await _audioPlayer.Received(1).LoadAsync(Arg.Is<Song>(song => song.FilePath == firstPath));
+        await _libraryService.DidNotReceive().StartListenSessionAsync(
+            externalIds[0], Arg.Any<PlaybackContext>());
     }
 
     #endregion


### PR DESCRIPTION
Closes #154.\n\n- accepts supported files and recursively enumerated folders on the queue flyout\n- keeps external tracks in a session-only queue map, mixed safely with library tracks\n- excludes transient entries from restored session state\n- preserves sidecar and embedded lyrics for external tracks