### PR TITLE
fix: expose the queue drop target

### DIFF
--- a/src/Nagi.WinUI/MainPage.xaml
+++ b/src/Nagi.WinUI/MainPage.xaml
@@ -89,7 +89,11 @@
             </DataTemplate>
 
             <DataTemplate x:Key="QueueButtonTemplate" x:DataType="uiModels:PlayerButtonSetting">
-                <Button ToolTipService.ToolTip="{x:Bind DynamicToolTip, Mode=OneTime}"
+                <Button AllowDrop="True"
+                        DragEnter="QueueButton_DragEnter"
+                        DragOver="QueueFlyout_DragOver"
+                        Drop="QueueFlyout_Drop"
+                        ToolTipService.ToolTip="{x:Bind DynamicToolTip, Mode=OneTime}"
                         Style="{StaticResource QueueButtonStyle}">
                     <FontIcon FontFamily="{ThemeResource SymbolThemeFontFamily}" Glyph="{x:Bind DynamicIcon, Mode=OneWay}" />
                     <Button.Flyout>

--- a/src/Nagi.WinUI/MainPage.xaml.cs
+++ b/src/Nagi.WinUI/MainPage.xaml.cs
@@ -183,6 +183,14 @@ public sealed partial class MainPage : UserControl, ICustomTitleBarProvider
             e.AcceptedOperation = DataPackageOperation.Copy;
     }
 
+    private void QueueButton_DragEnter(object sender, DragEventArgs e)
+    {
+        QueueFlyout_DragOver(sender, e);
+        if (e.AcceptedOperation == DataPackageOperation.Copy &&
+            !_isQueueFlyoutOpen && sender is Button button)
+            button.Flyout?.ShowAt(button);
+    }
+
     private async void QueueFlyout_Drop(object sender, DragEventArgs e)
     {
         if (!e.DataView.Contains(StandardDataFormats.StorageItems)) return;


### PR DESCRIPTION
Follow-up to #154.\n\n- accepts drops directly on the queue button\n- opens the queue when a supported drag enters the button\n- keeps the existing flyout drop target\n\nVerified with a packaged desktop drag from File Explorer: an external file opened the queue, started transient playback, remained out of listen history, and loaded its sidecar lyrics.