### PR TITLE
Fix database locking during library scans

### DIFF
--- a/src/Nagi.Core/Services/Implementations/LibraryService.cs
+++ b/src/Nagi.Core/Services/Implementations/LibraryService.cs
@@ -54,7 +54,6 @@ public class LibraryService : ILibraryService, ILibraryReader, IDisposable
     private readonly ITheAudioDbService _theAudioDbService;
     private readonly ILogger<LibraryService> _logger;
     private readonly SemaphoreSlim _metadataFetchSemaphore = new(1, 1);
-    private readonly SemaphoreSlim _dbWriteSemaphore = new(1, 1);
     // These locks are only used by the single-song AddSongWithDetailsAsync API (not batch processing)
     private readonly SemaphoreSlim _artistCreationLock = new(1, 1);
     private readonly SemaphoreSlim _albumCreationLock = new(1, 1);
@@ -4163,11 +4162,6 @@ public class LibraryService : ILibraryService, ILibraryReader, IDisposable
             }
         }, pipelineToken);
 
-        // Single explicit transaction wrapping all batches — reduces SQLite fsyncs from N to 1.
-        // Each SaveChangesAsync writes SQL to the WAL without committing; CommitAsync() does a single fsync.
-        // ChangeTracker.Clear() between batches is safe: it only releases in-memory tracking, not the WAL data.
-        await using var scanTransaction = await batchContext.Database.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
-
         // Consumer: Batch and save to database as metadata arrives
         var consumerTask = Task.Run(async () =>
         {
@@ -4230,7 +4224,6 @@ public class LibraryService : ILibraryService, ILibraryReader, IDisposable
         }, pipelineToken);
 
         await Task.WhenAll(producerTask, consumerTask).ConfigureAwait(false);
-        await scanTransaction.CommitAsync(cancellationToken).ConfigureAwait(false);
 
         if (!failureSummary.IsEmpty)
         {
@@ -6088,7 +6081,6 @@ public class LibraryService : ILibraryService, ILibraryReader, IDisposable
 
             _shutdownCts.Dispose();
             _scanSemaphore.Dispose();
-            _dbWriteSemaphore.Dispose();
             _artistCreationLock.Dispose();
             _albumCreationLock.Dispose();
             _metadataFetchSemaphore.Dispose();

--- a/tests/Nagi.Core.Tests/LibraryServiceBugTests.cs
+++ b/tests/Nagi.Core.Tests/LibraryServiceBugTests.cs
@@ -52,7 +52,7 @@ public class LibraryServiceBugTests : IDisposable
         _imageProcessor = Substitute.For<IImageProcessor>();
         _logger = Substitute.For<ILogger<LibraryService>>();
 
-        _dbHelper = new DbContextFactoryTestHelper();
+        _dbHelper = new DbContextFactoryTestHelper(useFileDatabase: true);
         _pipelines = TestProviderPipeline.Build(ServiceProviderIds.ImageDownload);
 
         _libraryService = new LibraryService(
@@ -141,6 +141,75 @@ public class LibraryServiceBugTests : IDisposable
             .WaitAsync(TimeSpan.FromSeconds(5));
 
         result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task RescanFolderForMusicAsync_DuringSlowExtraction_AllowsListenHistoryWrites()
+    {
+        var folder = new Folder { Id = Guid.NewGuid(), Path = "C:\\Music\\ConcurrentScan", Name = "ConcurrentScan" };
+        var existingSong = new Song
+        {
+            Id = Guid.NewGuid(),
+            FolderId = folder.Id,
+            FilePath = "C:\\Music\\ConcurrentScan\\existing.mp3",
+            Title = "Existing"
+        };
+        await using (var context = _dbHelper.ContextFactory.CreateDbContext())
+        {
+            context.Folders.Add(folder);
+            context.Songs.Add(existingSong);
+            await context.SaveChangesAsync();
+        }
+
+        var slowFile = "C:\\Music\\ConcurrentScan\\slow.mp3";
+        var files = Enumerable.Range(1, 100)
+            .Select(i => ($"C:\\Music\\ConcurrentScan\\song{i}.mp3", DateTime.UtcNow))
+            .Append((slowFile, DateTime.UtcNow))
+            .Append((existingSong.FilePath, DateTime.UtcNow))
+            .ToList();
+        _fileSystem.DirectoryExists(folder.Path).Returns(true);
+        _fileSystem.EnumerateFilesWithLastWriteTime(folder.Path, "*.*", SearchOption.AllDirectories).Returns(files);
+        _fileSystem.GetExtension(Arg.Any<string>()).Returns(".mp3");
+
+        var releaseSlowExtraction = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        _metadataService.ExtractMetadataAsync(Arg.Any<string>(), folder.Path)
+            .Returns(async call =>
+            {
+                var path = call.ArgAt<string>(0);
+                if (path == slowFile)
+                    await releaseSlowExtraction.Task;
+                return new SongFileMetadata { FilePath = path, Title = Path.GetFileNameWithoutExtension(path) };
+            });
+
+        var scanTask = _libraryService.RescanFolderForMusicAsync(folder.Id);
+        try
+        {
+            await WaitForSongCountAsync(51);
+            var sessionId = await _libraryService.StartListenSessionAsync(
+                existingSong.Id,
+                new PlaybackContext(PlaybackContextType.Library, null));
+
+            sessionId.Should().NotBeNull();
+        }
+        finally
+        {
+            releaseSlowExtraction.TrySetResult();
+            await scanTask.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+    }
+
+    private async Task WaitForSongCountAsync(int expected)
+    {
+        var deadline = DateTime.UtcNow.AddSeconds(5);
+        while (DateTime.UtcNow < deadline)
+        {
+            await using var context = _dbHelper.ContextFactory.CreateDbContext();
+            if (await context.Songs.CountAsync() >= expected)
+                return;
+            await Task.Delay(20);
+        }
+
+        throw new TimeoutException($"Expected at least {expected} songs.");
     }
 
     [Fact]

--- a/tests/Nagi.Core.Tests/Utils/DbContextFactoryTestHelper.cs
+++ b/tests/Nagi.Core.Tests/Utils/DbContextFactoryTestHelper.cs
@@ -5,27 +5,34 @@ using Nagi.Core.Data;
 namespace Nagi.Core.Tests.Utils;
 
 /// <summary>
-///     A helper class for creating an in-memory SQLite database context factory for testing purposes.
-///     Each instance creates a unique, isolated database connection that is disposed of with the helper.
+///     Creates an isolated SQLite database for each test.
 /// </summary>
 public class DbContextFactoryTestHelper : IDisposable
 {
-    private readonly SqliteConnection _connection;
+    private readonly SqliteConnection? _connection;
+    private readonly string? _databasePath;
 
     /// <summary>
-    ///     Initializes a new instance of the <see cref="DbContextFactoryTestHelper" /> class,
-    ///     creating a new in-memory SQLite database.
+    ///     Creates an in-memory database by default, or a file database for concurrency tests.
     /// </summary>
-    public DbContextFactoryTestHelper()
+    public DbContextFactoryTestHelper(bool useFileDatabase = false)
     {
-        // Use "DataSource=:memory:" for a private in-memory database that is deleted when the connection is closed.
-        // "Mode=Memory" and "Cache=Shared" can be used for a shared in-memory database if needed across multiple connections.
-        _connection = new SqliteConnection("DataSource=:memory:");
-        _connection.Open();
-
-        var options = new DbContextOptionsBuilder<MusicDbContext>()
-            .UseSqlite(_connection)
-            .Options;
+        DbContextOptions<MusicDbContext> options;
+        if (useFileDatabase)
+        {
+            _databasePath = Path.Combine(Path.GetTempPath(), $"nagi-tests-{Guid.NewGuid():N}.db");
+            options = new DbContextOptionsBuilder<MusicDbContext>()
+                .UseSqlite($"Data Source={_databasePath};Pooling=False")
+                .Options;
+        }
+        else
+        {
+            _connection = new SqliteConnection("DataSource=:memory:");
+            _connection.Open();
+            options = new DbContextOptionsBuilder<MusicDbContext>()
+                .UseSqlite(_connection)
+                .Options;
+        }
 
         // Ensure the database schema is created
         using (var context = new MusicDbContext(options))
@@ -46,8 +53,13 @@ public class DbContextFactoryTestHelper : IDisposable
     /// </summary>
     public void Dispose()
     {
-        _connection.Close();
-        _connection.Dispose();
+        _connection?.Dispose();
+        if (_databasePath is not null)
+        {
+            File.Delete(_databasePath);
+            File.Delete($"{_databasePath}-wal");
+            File.Delete($"{_databasePath}-shm");
+        }
         GC.SuppressFinalize(this);
     }
 


### PR DESCRIPTION
## Summary
- commit completed scan batches independently instead of holding SQLite's writer lock across metadata extraction
- keep playback history and other database writes responsive during long rescans
- cover concurrent scanning and listen-history writes with a file-backed SQLite regression test

## Verification
- 845 core tests pass
- x64 Release publish succeeds
- packaged desktop test: switched tracks during a 1,023-file rescan; both sessions persisted and the scan completed without database-lock or fire-and-forget errors

Related to #133.