### PR TITLE
Bump version to 2.2.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,6 +13,6 @@
         <WindowsSdkVersion>10.0.26100</WindowsSdkVersion>
         <WindowsTargetPlatformMinVersion>10.0.17763.0</WindowsTargetPlatformMinVersion>
         <WindowsTargetPlatformMaxTestedVersion>10.0.26100.0</WindowsTargetPlatformMaxTestedVersion>
-        <AppxPackageVersion>2.1.1.0</AppxPackageVersion>
+        <AppxPackageVersion>2.2.0.0</AppxPackageVersion>
     </PropertyGroup>
 </Project>

--- a/src/Nagi.WinUI/Package.appxmanifest
+++ b/src/Nagi.WinUI/Package.appxmanifest
@@ -11,7 +11,7 @@
     <Identity
             Name="48743Nagi.Nagi"
             Publisher="CN=83B77A15-7BA2-452B-A4A0-9DD253FA3D0E"
-            Version="2.1.1.0"/>
+            Version="2.2.0.0"/>
 
     <Properties>
         <DisplayName>ms-resource:Resources/AppName</DisplayName>


### PR DESCRIPTION
## Summary
- bump the shared app/package version to 2.2.0.0
- keep the Microsoft Store manifest version in sync

## Verification
- 845 Release tests pass
- x64 and ARM64 ReadyToRun publishes succeed
- localization audit found no new user-facing strings in this release